### PR TITLE
HSEARCH-2623 Make the optional parameters truly optional

### DIFF
--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.jsr352.massindexing;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -22,15 +23,15 @@ import org.hibernate.search.jsr352.massindexing.impl.util.MassIndexerUtil;
  * Use it like this:
  * <code><pre>
  * jobOperator.start(
- *		MassIndexingJob.NAME,
- *		MassIndexingJob.parameters()
- *			.forEntities( String.class, Integer.class )
- *			.fetchSize( 1000 )
- *			.rowsPerPartition( 10_000 )
- *			.maxResults( 1000 )
- *			.maxThreads( 30 )
- *			.purgeAtStart( true )
- *			.build()
+ * 		MassIndexingJob.NAME,
+ * 		MassIndexingJob.parameters()
+ * 			.forEntities( String.class, Integer.class )
+ * 			.fetchSize( 1000 )
+ * 			.rowsPerPartition( 10_000 )
+ * 			.maxResults( 1000 )
+ * 			.maxThreads( 30 )
+ * 			.purgeAtStart( true )
+ * 			.build()
  * );
  * </pre></code>
  *
@@ -87,9 +88,7 @@ public final class MassIndexingJob {
 			}
 			this.rootEntities = new HashSet<>();
 			this.rootEntities.add( rootEntity );
-			for ( Class<?> clz : rootEntities ) {
-				this.rootEntities.add( clz );
-			}
+			Collections.addAll( this.rootEntities, rootEntities );
 			customQueryCriteria = new HashSet<>();
 			customQueryHql = "";
 		}
@@ -106,10 +105,11 @@ public final class MassIndexingJob {
 
 		/**
 		 * Whether the Hibernate queries are cacheable. This setting will be applied to
-		 * {@link org.hibernate.search.jsr352.massindexing.impl.steps.lucene.EntityReader} . The default value is false. Set it
-		 * to true when reading a complex graph with relations.
+		 * {@link org.hibernate.search.jsr352.massindexing.impl.steps.lucene.EntityReader} . The default value is false.
+		 * Set it to true when reading a complex graph with relations.
 		 *
 		 * @param cacheable
+		 *
 		 * @return
 		 */
 		public ParametersBuilder cacheable(boolean cacheable) {
@@ -119,10 +119,11 @@ public final class MassIndexingJob {
 
 		/**
 		 * Checkpoint interval during the mass index process.
-		 *
+		 * <p>
 		 * The checkpoint will be done every N items read, where N is the given item count.
 		 *
 		 * @param checkpointInterval the number of item count before starting the next checkpoint.
+		 *
 		 * @return
 		 */
 		public ParametersBuilder checkpointInterval(int checkpointInterval) {
@@ -134,6 +135,7 @@ public final class MassIndexingJob {
 		 * The fetch size for the result fetching.
 		 *
 		 * @param fetchSize
+		 *
 		 * @return
 		 */
 		public ParametersBuilder fetchSize(int fetchSize) {
@@ -149,6 +151,7 @@ public final class MassIndexingJob {
 		 * SQL.
 		 *
 		 * @param customQueryLimit
+		 *
 		 * @return
 		 */
 		public ParametersBuilder customQueryLimit(int customQueryLimit) {
@@ -165,6 +168,7 @@ public final class MassIndexingJob {
 		 * maximum. This an an optional attribute. The default is the number of partitions.
 		 *
 		 * @param maxThreads
+		 *
 		 * @return
 		 */
 		public ParametersBuilder maxThreads(int maxThreads) {
@@ -181,6 +185,7 @@ public final class MassIndexingJob {
 		 * TODO: specify what is the optimization exactly
 		 *
 		 * @param optimizeAfterPurge
+		 *
 		 * @return
 		 */
 		public ParametersBuilder optimizeAfterPurge(boolean optimizeAfterPurge) {
@@ -194,6 +199,7 @@ public final class MassIndexingJob {
 		 * exactly
 		 *
 		 * @param optimizeOnFinish
+		 *
 		 * @return
 		 */
 		public ParametersBuilder optimizeOnFinish(boolean optimizeOnFinish) {
@@ -206,6 +212,7 @@ public final class MassIndexingJob {
 		 * place before the step of lucene document production. The default value is false.
 		 *
 		 * @param purgeAllOnStart
+		 *
 		 * @return
 		 */
 		public ParametersBuilder purgeAllOnStart(boolean purgeAllOnStart) {
@@ -217,12 +224,12 @@ public final class MassIndexingJob {
 		 * Add criterion to choose the set of entities to index.
 		 *
 		 * @param criterion
+		 *
 		 * @return
 		 */
 		public ParametersBuilder restrictedBy(Criterion criterion) {
 			if ( !customQueryHql.isEmpty() ) {
-				throw new IllegalArgumentException( "Cannot use HQL approach "
-						+ "and Criteria approach in the same time." );
+				throw new IllegalArgumentException( "Cannot use HQL approach and Criteria approach in the same time." );
 			}
 			if ( criterion == null ) {
 				throw new NullPointerException( "The criterion is null." );
@@ -235,6 +242,7 @@ public final class MassIndexingJob {
 		 * Use HQL / JPQL to select to entities to index
 		 *
 		 * @param hql
+		 *
 		 * @return
 		 */
 		public ParametersBuilder restrictedBy(String hql) {
@@ -242,8 +250,7 @@ public final class MassIndexingJob {
 				throw new NullPointerException( "The HQL is null." );
 			}
 			if ( customQueryCriteria.size() > 0 ) {
-				throw new IllegalArgumentException( "Cannot use HQL approach "
-						+ "and Criteria approach in the same time." );
+				throw new IllegalArgumentException( "Cannot use HQL approach and Criteria approach in the same time." );
 			}
 			this.customQueryHql = hql;
 			return this;
@@ -252,7 +259,8 @@ public final class MassIndexingJob {
 		/**
 		 * Define the max number of rows to process per partition.
 		 *
-		 * @param partitionCapacity
+		 * @param rowsPerPartition
+		 *
 		 * @return
 		 */
 		public ParametersBuilder rowsPerPartition(int rowsPerPartition) {
@@ -268,6 +276,7 @@ public final class MassIndexingJob {
 		 * Build the parameters.
 		 *
 		 * @return The parameters.
+		 *
 		 * @throws SearchException if the serialization of some parameters fail.
 		 */
 		public Properties build() {
@@ -277,7 +286,10 @@ public final class MassIndexingJob {
 				jobParams.put( MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE, entityManagerFactoryScope );
 			}
 			if ( entityManagerFactoryReference != null ) {
-				jobParams.put( MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE, entityManagerFactoryReference );
+				jobParams.put(
+						MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE,
+						entityManagerFactoryReference
+				);
 			}
 			jobParams.put( MassIndexingJobParameters.CACHEABLE, String.valueOf( cacheable ) );
 			jobParams.put( MassIndexingJobParameters.FETCH_SIZE, String.valueOf( fetchSize ) );
@@ -293,7 +305,10 @@ public final class MassIndexingJob {
 
 			if ( !customQueryCriteria.isEmpty() ) {
 				try {
-					jobParams.put( MassIndexingJobParameters.CUSTOM_QUERY_CRITERIA, MassIndexerUtil.serializeCriteria( customQueryCriteria ) );
+					jobParams.put(
+							MassIndexingJobParameters.CUSTOM_QUERY_CRITERIA,
+							MassIndexerUtil.serializeCriteria( customQueryCriteria )
+					);
 				}
 				catch (IOException e) {
 					throw new SearchException( "Failed to serialize Criteria", e );
@@ -305,8 +320,9 @@ public final class MassIndexingJob {
 
 		private String getRootEntitiesAsString() {
 			return rootEntities.stream()
-					.map( (e) -> e.getName() )
+					.map( Class::getName )
 					.collect( Collectors.joining( "," ) );
 		}
 	}
+
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -65,22 +65,26 @@ public final class MassIndexingJob {
 		}
 	}
 
+	/**
+	 * Parameter builder for mass-indexing job. The default value of each parameter is defined in the job XML file
+	 * {@code hibernate-search-mass-indexing.xml}.
+	 */
 	public static class ParametersBuilder {
 
 		private final Set<Class<?>> rootEntities;
 		private String entityManagerFactoryScope;
 		private String entityManagerFactoryReference;
-		private boolean cacheable = false;
-		private boolean optimizeAfterPurge = false;
-		private boolean optimizeOnFinish = false;
-		private boolean purgeAllOnStart = false;
-		private int fetchSize = 200 * 1000;
-		private int checkpointInterval = 200;
-		private int rowsPerPartition = 250;
-		private int maxThreads = 1;
+		private Boolean cacheable;
+		private Boolean optimizeAfterPurge;
+		private Boolean optimizeOnFinish;
+		private Boolean purgeAllOnStart;
+		private Integer fetchSize;
+		private Integer checkpointInterval;
+		private Integer rowsPerPartition;
+		private Integer maxThreads;
 		private Set<Criterion> customQueryCriteria;
 		private String customQueryHql;
-		private int customQueryLimit = 1000 * 1000;
+		private Integer customQueryLimit;
 
 		private ParametersBuilder(Class<?> rootEntity, Class<?>... rootEntities) {
 			if ( rootEntity == null ) {
@@ -90,7 +94,6 @@ public final class MassIndexingJob {
 			this.rootEntities.add( rootEntity );
 			Collections.addAll( this.rootEntities, rootEntities );
 			customQueryCriteria = new HashSet<>();
-			customQueryHql = "";
 		}
 
 		public ParametersBuilder entityManagerFactoryScope(String scope) {
@@ -228,7 +231,7 @@ public final class MassIndexingJob {
 		 * @return
 		 */
 		public ParametersBuilder restrictedBy(Criterion criterion) {
-			if ( !customQueryHql.isEmpty() ) {
+			if ( customQueryHql != null ) {
 				throw new IllegalArgumentException( "Cannot use HQL approach and Criteria approach in the same time." );
 			}
 			if ( criterion == null ) {
@@ -282,26 +285,19 @@ public final class MassIndexingJob {
 		public Properties build() {
 			Properties jobParams = new Properties();
 
-			if ( entityManagerFactoryScope != null ) {
-				jobParams.put( MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE, entityManagerFactoryScope );
-			}
-			if ( entityManagerFactoryReference != null ) {
-				jobParams.put(
-						MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE,
-						entityManagerFactoryReference
-				);
-			}
-			jobParams.put( MassIndexingJobParameters.CACHEABLE, String.valueOf( cacheable ) );
-			jobParams.put( MassIndexingJobParameters.FETCH_SIZE, String.valueOf( fetchSize ) );
-			jobParams.put( MassIndexingJobParameters.CUSTOM_QUERY_HQL, customQueryHql );
-			jobParams.put( MassIndexingJobParameters.CHECKPOINT_INTERVAL, String.valueOf( checkpointInterval ) );
-			jobParams.put( MassIndexingJobParameters.CUSTOM_QUERY_LIMIT, String.valueOf( customQueryLimit ) );
-			jobParams.put( MassIndexingJobParameters.MAX_THREADS, String.valueOf( maxThreads ) );
-			jobParams.put( MassIndexingJobParameters.OPTIMIZE_AFTER_PURGE, String.valueOf( optimizeAfterPurge ) );
-			jobParams.put( MassIndexingJobParameters.OPTIMIZE_ON_FINISH, String.valueOf( optimizeOnFinish ) );
-			jobParams.put( MassIndexingJobParameters.PURGE_ALL_ON_START, String.valueOf( purgeAllOnStart ) );
-			jobParams.put( MassIndexingJobParameters.ROOT_ENTITIES, getRootEntitiesAsString() );
-			jobParams.put( MassIndexingJobParameters.ROWS_PER_PARTITION, String.valueOf( rowsPerPartition ) );
+			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE, entityManagerFactoryScope );
+			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE, entityManagerFactoryReference );
+			addIfNotNull( jobParams, MassIndexingJobParameters.CACHEABLE, cacheable );
+			addIfNotNull( jobParams, MassIndexingJobParameters.FETCH_SIZE, fetchSize );
+			addIfNotNull( jobParams, MassIndexingJobParameters.CUSTOM_QUERY_HQL, customQueryHql );
+			addIfNotNull( jobParams, MassIndexingJobParameters.CHECKPOINT_INTERVAL, checkpointInterval );
+			addIfNotNull( jobParams, MassIndexingJobParameters.CUSTOM_QUERY_LIMIT, customQueryLimit );
+			addIfNotNull( jobParams, MassIndexingJobParameters.MAX_THREADS, maxThreads );
+			addIfNotNull( jobParams, MassIndexingJobParameters.OPTIMIZE_AFTER_PURGE, optimizeAfterPurge );
+			addIfNotNull( jobParams, MassIndexingJobParameters.OPTIMIZE_ON_FINISH, optimizeOnFinish );
+			addIfNotNull( jobParams, MassIndexingJobParameters.PURGE_ALL_ON_START, purgeAllOnStart );
+			addIfNotNull( jobParams, MassIndexingJobParameters.ROOT_ENTITIES, getRootEntitiesAsString() );
+			addIfNotNull( jobParams, MassIndexingJobParameters.ROWS_PER_PARTITION, rowsPerPartition );
 
 			if ( !customQueryCriteria.isEmpty() ) {
 				try {
@@ -322,6 +318,12 @@ public final class MassIndexingJob {
 			return rootEntities.stream()
 					.map( Class::getName )
 					.collect( Collectors.joining( "," ) );
+		}
+
+		private void addIfNotNull(Properties properties, String key, Object value) {
+			if ( value != null ) {
+				properties.put( key, String.valueOf( value ) );
+			}
 		}
 	}
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
@@ -56,7 +56,7 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 
 	@Inject
 	@BatchProperty(name = MassIndexingJobParameters.CUSTOM_QUERY_HQL)
-	private String hql;
+	private String customQueryHql;
 
 	@Inject
 	@BatchProperty(name = MassIndexingJobParameters.MAX_THREADS)
@@ -76,18 +76,18 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 	 *
 	 * @param emf
 	 * @param fetchSize
-	 * @param hql
+	 * @param customQueryHql
 	 * @param maxThreads
 	 * @param rowsPerPartition
 	 */
 	PartitionMapper(EntityManagerFactory emf,
 			String fetchSize,
-			String hql,
+			String customQueryHql,
 			String rowsPerPartition,
 			String maxThreads) {
 		this.emf = emf;
 		this.fetchSize = fetchSize;
-		this.hql = hql;
+		this.customQueryHql = customQueryHql;
 		this.maxThreads = maxThreads;
 		this.rowsPerPartition = rowsPerPartition;
 	}
@@ -111,7 +111,7 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 			List<PartitionBound> partitionBounds = new ArrayList<>();
 			Class<?> entityType;
 
-			switch ( typeOfSelection( hql, jobData.getCustomQueryCriteria() ) ) {
+			switch ( typeOfSelection( customQueryHql, jobData.getCustomQueryCriteria() ) ) {
 				case HQL:
 					entityType = rootEntities.get( 0 );
 					partitionBounds.add( new PartitionBound( entityType, null, null ) );

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -29,8 +29,8 @@
     <step id="beforeChunk" next="produceLuceneDoc">
         <batchlet ref="org.hibernate.search.jsr352.massindexing.impl.steps.beforechunk.BeforeChunkBatchlet">
             <properties>
-                <property name="optimizeAfterPurge" value="#{jobParameters['optimizeAfterPurge']}" />
-                <property name="purgeAllOnStart" value="#{jobParameters['purgeAllOnStart']}" />
+                <property name="optimizeAfterPurge" value="#{jobParameters['optimizeAfterPurge']}?:false;" />
+                <property name="purgeAllOnStart" value="#{jobParameters['purgeAllOnStart']}?:false;" />
             </properties>
         </batchlet>
     </step>
@@ -39,7 +39,7 @@
         <listeners>
             <listener ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.StepProgressSetupListener">
                 <properties>
-                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}" />
+                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}?:false;" />
                 </properties>
             </listener>
         </listeners>
@@ -51,7 +51,7 @@
                     <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:200000;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
-                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}" />
+                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}?:false;" />
                     <property name="customQueryLimit" value="#{jobParameters['customQueryLimit']}?:10000000;" />
                 </properties>
             </reader>
@@ -79,8 +79,8 @@
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:200000;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
                     <property name="isJavaSE" value="#{jobParameters['isJavaSE']}?:false;" />
-                    <property name="maxThreads" value="#{jobParameters['threads']}?:8;" />
-                    <property name="rowsPerPartition" value="#{jobParameters['rowsPerPartition']}?:0;" />
+                    <property name="maxThreads" value="#{jobParameters['maxThreads']}?:8;" />
+                    <property name="rowsPerPartition" value="#{jobParameters['rowsPerPartition']}?:250;" />
                 </properties>
             </mapper>
             <collector ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.ProgressCollector" />
@@ -91,7 +91,7 @@
     <step id="afterChunk">
         <batchlet ref="org.hibernate.search.jsr352.massindexing.impl.steps.afterchunk.AfterChunkBatchlet">
             <properties>
-                <property name="optimizeOnFinish" value="#{jobParameters['optimizeOnFinish']}" />
+                <property name="optimizeOnFinish" value="#{jobParameters['optimizeOnFinish']}?:false;" />
             </properties>
         </batchlet>
     </step>

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -37,11 +37,7 @@
 
     <step id="produceLuceneDoc" next="afterChunk">
         <listeners>
-            <listener ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.StepProgressSetupListener">
-                <properties>
-                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}?:false;" />
-                </properties>
-            </listener>
+            <listener ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.StepProgressSetupListener" />
         </listeners>
         <chunk checkpoint-policy="custom">
             <reader ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.EntityReader">
@@ -51,20 +47,17 @@
                     <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:200000;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
-                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}?:false;" />
                     <property name="customQueryLimit" value="#{jobParameters['customQueryLimit']}?:10000000;" />
                 </properties>
             </reader>
             <processor ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.LuceneDocProducer">
                 <properties>
                     <property name="entityName" value="#{partitionPlan['entityName']}" />
-                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}?:false;" />
                 </properties>
             </processor>
             <writer ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.LuceneDocWriter">
                 <properties>
                     <property name="entityName" value="#{partitionPlan['entityName']}" />
-                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}?:false;" />
                 </properties>
             </writer>
             <checkpoint-algorithm ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.CheckpointAlgorithm">
@@ -78,7 +71,6 @@
                 <properties>
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:200000;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
-                    <property name="isJavaSE" value="#{jobParameters['isJavaSE']}?:false;" />
                     <property name="maxThreads" value="#{jobParameters['maxThreads']}?:8;" />
                     <property name="rowsPerPartition" value="#{jobParameters['rowsPerPartition']}?:250;" />
                 </properties>

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -95,4 +95,5 @@
             </properties>
         </batchlet>
     </step>
+
 </job>

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/RestartChunkIT.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/RestartChunkIT.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
 				targetClass = "org.hibernate.search.jsr352.massindexing.impl.steps.lucene.PartitionMapper",
 				targetMethod = "mapPartitions",
 				targetLocation = "AT EXIT",
-				action = "createCountDown(\"beforeRestart\", 100)"
+				action = "createCountDown(\"beforeRestart\", " + RestartChunkIT.ITEMS_BEFORE_SIMULATED_FAILURE + ")"
 		),
 		@BMRule(
 				name = "Count down for each item read, interrupt the job when counter is 0",
@@ -55,6 +55,8 @@ import org.junit.runner.RunWith;
 		)
 })
 public class RestartChunkIT {
+
+	static final int ITEMS_BEFORE_SIMULATED_FAILURE = 100;
 
 	private static final String PERSISTENCE_UNIT_NAME = "h2";
 
@@ -112,6 +114,7 @@ public class RestartChunkIT {
 				MassIndexingJob.parameters()
 						.forEntities( Company.class, Person.class )
 						.entityManagerFactoryReference( PERSISTENCE_UNIT_NAME )
+						// must be smaller than ITEMS_BEFORE_SIMULATED_FAILURE to trigger the restart
 						.checkpointInterval( 10 )
 						.build()
 		);

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
@@ -6,11 +6,19 @@
  */
 package org.hibernate.search.jsr352.test.util;
 
+import java.util.List;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.jpa.Search;
 
 import org.jboss.logging.Logger;
+
+import org.apache.lucene.search.Query;
 
 /**
  * @author Yoann Rodiere
@@ -44,6 +52,19 @@ public final class JobTestUtil {
 		}
 
 		return jobExecution;
+	}
+
+	public static <T> List<T> findIndexedResults(EntityManagerFactory emf, Class<T> clazz, String key, String value) {
+		EntityManager em = emf.createEntityManager();
+		FullTextEntityManager ftem = Search.getFullTextEntityManager( em );
+		Query luceneQuery = ftem.getSearchFactory().buildQueryBuilder()
+				.forEntity( clazz ).get()
+				.keyword().onField( key ).matching( value )
+				.createQuery();
+		@SuppressWarnings("unchecked")
+		List<T> result = ftem.createFullTextQuery( luceneQuery ).getResultList();
+		em.close();
+		return result;
 	}
 
 }


### PR DESCRIPTION
Hi @yrodiere , this PR aims the make the JSR-352 optional parameters truly optional. See https://hibernate.atlassian.net/browse/HSEARCH-2623

I also did some cleanup on the related classes. I used the code style provided by [hibernate-ide-codestyles for IntelliJ](https://github.com/hibernate/hibernate-ide-codestyles/tree/master/intellij-14). I set the characters limit to 120, but I'm not sure if this is correct.

Have a nice week!
