### PR TITLE
HSEARCH-2638 Enhance restriction for 'checkpointInterval'

### DIFF
--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/logging/impl/Log.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/logging/impl/Log.java
@@ -199,4 +199,20 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 			value = "entityName: '%1$s', rowsToIndex: %2$d")
 	void rowsToIndex(String entityName, long rowsToIndex);
 
+	@Message(id = JSR_352_MESSAGES_START_ID + 28,
+			value = "Unable to parse value '%1$s' for job parameter '%2$s'."
+	)
+	SearchException unableToParseJobParameter(String parameterName, Object parameterValue, @Cause Exception e);
+
+	@Message(id = JSR_352_MESSAGES_START_ID + 29,
+			value = "The value of parameter 'checkpointInterval' (value=%1$d) should be less than"
+					+ " the value of parameter 'rowsPerPartition' (value=%2$d)."
+	)
+	SearchException illegalCheckpointInterval(int checkpointInterval, int rowsPerPartition);
+
+	@Message(id = JSR_352_MESSAGES_START_ID + 30,
+			value = "The value of parameter '%1$s' (value=%2$d) should be greater than 0."
+	)
+	SearchException negativeValueOrZero(String parameterName, Number parameterValue);
+
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/JobParameterValidationListener.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/JobParameterValidationListener.java
@@ -1,0 +1,69 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing;
+
+import javax.batch.api.BatchProperty;
+import javax.batch.api.listener.AbstractJobListener;
+import javax.inject.Inject;
+
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.jsr352.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+import static org.hibernate.search.jsr352.massindexing.impl.util.ValidationUtil.validateCheckpointInterval;
+import static org.hibernate.search.jsr352.massindexing.impl.util.ValidationUtil.validatePositive;
+
+/**
+ * Listener for job parameters validations before the start of a job execution.
+ *
+ * @author Mincong Huang
+ */
+public class JobParameterValidationListener extends AbstractJobListener {
+
+	private static final Log log = LoggerFactory.make( Log.class );
+
+	@Inject
+	@BatchProperty(name = MassIndexingJobParameters.CHECKPOINT_INTERVAL)
+	private String checkpointIntervalStr;
+
+	@Inject
+	@BatchProperty(name = MassIndexingJobParameters.ROWS_PER_PARTITION)
+	private String rowsPerPartitionStr;
+
+	public JobParameterValidationListener() {
+	}
+
+	JobParameterValidationListener(String checkpointIntervalStr, String rowsPerPartitionStr) {
+		this.checkpointIntervalStr = checkpointIntervalStr;
+		this.rowsPerPartitionStr = rowsPerPartitionStr;
+	}
+
+	/**
+	 * Validate job parameters.
+	 *
+	 * @throws SearchException if any validation fails.
+	 */
+	@Override
+	public void beforeJob() throws SearchException {
+		int checkpointInterval = parseInt( MassIndexingJobParameters.CHECKPOINT_INTERVAL, checkpointIntervalStr );
+		int rowsPerPartition = parseInt( MassIndexingJobParameters.ROWS_PER_PARTITION, rowsPerPartitionStr );
+
+		validatePositive( MassIndexingJobParameters.CHECKPOINT_INTERVAL, checkpointInterval );
+		validatePositive( MassIndexingJobParameters.ROWS_PER_PARTITION, rowsPerPartition );
+		validateCheckpointInterval( checkpointInterval, rowsPerPartition );
+	}
+
+	private int parseInt(String parameterName, String parameterValue) {
+		try {
+			return Integer.parseInt( parameterValue );
+		}
+		catch (NumberFormatException e) {
+			throw log.unableToParseJobParameter( parameterName, parameterValue, e );
+		}
+	}
+
+}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -18,6 +18,7 @@ import org.hibernate.criterion.Criterion;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.jsr352.logging.impl.Log;
 import org.hibernate.search.jsr352.massindexing.impl.util.SerializationUtil;
+import org.hibernate.search.jsr352.massindexing.impl.util.ValidationUtil;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
@@ -314,6 +315,8 @@ public final class MassIndexingJob {
 		 * @throws SearchException if the serialization of some parameters fail.
 		 */
 		public Properties build() {
+			ValidationUtil.validateCheckpointInterval( checkpointInterval, rowsPerPartition );
+
 			Properties jobParams = new Properties();
 
 			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE, entityManagerFactoryScope );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/ValidationUtil.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/ValidationUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.impl.util;
+
+import org.hibernate.search.jsr352.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * Utility class for job parameter validation.
+ *
+ * @author Mincong Huang
+ */
+public final class ValidationUtil {
+
+	private static final Log log = LoggerFactory.make( Log.class );
+
+	private ValidationUtil() {
+		// Private constructor, do not use it.
+	}
+
+	public static void validateCheckpointInterval(Integer checkpointInterval, Integer rowsPerPartitions) {
+		if ( checkpointInterval != null && rowsPerPartitions != null && checkpointInterval >= rowsPerPartitions ) {
+			throw log.illegalCheckpointInterval( checkpointInterval, rowsPerPartitions );
+		}
+	}
+
+	public static void validatePositive(String parameterName, int parameterValue) {
+		if ( parameterValue <= 0 ) {
+			throw log.negativeValueOrZero( parameterName, parameterValue );
+		}
+	}
+
+}

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -9,6 +9,12 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" version="1.0">
 
     <listeners>
+        <listener ref="org.hibernate.search.jsr352.massindexing.JobParameterValidationListener">
+            <properties>
+                <property name="checkpointInterval" value="#{jobParameters['checkpointInterval']}?:200;" />
+                <property name="rowsPerPartition" value="#{jobParameters['rowsPerPartition']}?:250;" />
+            </properties>
+        </listener>
         <listener ref="org.hibernate.search.jsr352.massindexing.impl.JobContextSetupListener">
             <properties>
                 <property name="entityManagerFactoryScope" value="#{jobParameters['entityManagerFactoryScope']}" />

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/JobParameterValidationListenerTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/JobParameterValidationListenerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing;
+
+import org.hibernate.search.exception.SearchException;
+
+import org.junit.Test;
+
+/**
+ * @author Mincong Huang
+ */
+public class JobParameterValidationListenerTest {
+
+	private JobParameterValidationListener validationListener;
+
+	@Test(expected = SearchException.class)
+	public void validateRowsPerPartition_valueIsNegative() throws Exception {
+		String checkpointIntervalStr = "100";
+		String rowsPerPartitionStr = "-1";
+		validationListener = new JobParameterValidationListener( checkpointIntervalStr, rowsPerPartitionStr );
+		validationListener.beforeJob();
+	}
+
+	@Test(expected = SearchException.class)
+	public void validateRowsPerPartition_valueIsZero() throws Exception {
+		String checkpointIntervalStr = "100";
+		String rowsPerPartitionStr = "0";
+		validationListener = new JobParameterValidationListener( checkpointIntervalStr, rowsPerPartitionStr );
+		validationListener.beforeJob();
+	}
+
+	@Test(expected = SearchException.class)
+	public void validateCheckpointInterval_valueIsNegative() throws Exception {
+		String checkpointIntervalStr = "-1";
+		String rowsPerPartitionStr = "100";
+		validationListener = new JobParameterValidationListener( checkpointIntervalStr, rowsPerPartitionStr );
+		validationListener.beforeJob();
+	}
+
+	@Test(expected = SearchException.class)
+	public void validateCheckpointInterval_valueIsZero() throws Exception {
+		String checkpointIntervalStr = "0";
+		String rowsPerPartitionStr = "100";
+		validationListener = new JobParameterValidationListener( checkpointIntervalStr, rowsPerPartitionStr );
+		validationListener.beforeJob();
+	}
+
+	@Test(expected = SearchException.class)
+	public void validateCheckpointInterval_greaterThanRowsPerPartitions() throws Exception {
+		String checkpointIntervalStr = "101";
+		String rowsPerPartitionStr = "100";
+		validationListener = new JobParameterValidationListener( checkpointIntervalStr, rowsPerPartitionStr );
+		validationListener.beforeJob();
+	}
+
+	@Test(expected = SearchException.class)
+	public void validateCheckpointInterval_equalToRowsPerPartitions() throws Exception {
+		String checkpointIntervalStr = "100";
+		String rowsPerPartitionStr = "100";
+		validationListener = new JobParameterValidationListener( checkpointIntervalStr, rowsPerPartitionStr );
+		validationListener.beforeJob();
+	}
+
+	@Test
+	public void validateCheckpointInterval_lessThanRowsPerPartitions() throws Exception {
+		String checkpointIntervalStr = "99";
+		String rowsPerPartitionStr = "100";
+		validationListener = new JobParameterValidationListener( checkpointIntervalStr, rowsPerPartitionStr );
+		validationListener.beforeJob();
+		// ok, no exception
+	}
+
+}

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParametersBuilderTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParametersBuilderTest.java
@@ -16,6 +16,8 @@ import java.util.Properties;
 
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.search.exception.SearchException;
+
 import org.junit.Test;
 
 /**
@@ -104,6 +106,24 @@ public class MassIndexingJobParametersBuilderTest {
 		MassIndexingJob.parameters().forEntity( String.class ).restrictedBy( (Criterion) null );
 	}
 
+	@Test(expected = SearchException.class)
+	public void testCheckpointInterval_greaterThanRowsPerPartitions() {
+		MassIndexingJob.parameters()
+				.forEntity( UnusedEntity.class )
+				.checkpointInterval( 5 )
+				.rowsPerPartition( 4 )
+				.build();
+	}
+
+	@Test(expected = SearchException.class)
+	public void testCheckpointInterval_equalToRowsPerPartitions() {
+		MassIndexingJob.parameters()
+				.forEntity( UnusedEntity.class )
+				.checkpointInterval( 4 )
+				.rowsPerPartition( 4 )
+				.build();
+	}
+
 	/**
 	 * A batch indexing job cannot have 2 types of restrictions in the same time. Either JPQL / HQL or Criteria approach
 	 * is used. Using both will leads to illegal argument exception.
@@ -115,4 +135,10 @@ public class MassIndexingJobParametersBuilderTest {
 				.restrictedBy( "from string" )
 				.restrictedBy( Restrictions.isEmpty( "dummy" ) );
 	}
+
+	private static class UnusedEntity {
+		private UnusedEntity() {
+		}
+	}
+
 }

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/util/ValidationUtilTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/util/ValidationUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.impl.util;
+
+import org.hibernate.search.exception.SearchException;
+
+import org.junit.Test;
+
+/**
+ * @author Mincong Huang
+ */
+public class ValidationUtilTest {
+
+	@Test(expected = SearchException.class)
+	public void validatePositive_valueIsNegative() throws Exception {
+		ValidationUtil.validatePositive( "MyParameter", -1 );
+	}
+
+	@Test(expected = SearchException.class)
+	public void validatePositive_valueIsZero() throws Exception {
+		ValidationUtil.validatePositive( "MyParameter", 0 );
+	}
+
+	@Test
+	public void validatePositive_valueIsPositive() throws Exception {
+		ValidationUtil.validatePositive( "MyParameter", 1 );
+		// ok
+	}
+
+	@Test
+	public void validateCheckpointInterval_checkpointIntervalIsNull() throws Exception {
+		ValidationUtil.validateCheckpointInterval( null, 100 );
+		// ok
+	}
+
+	@Test
+	public void validateCheckpointInterval_rowsPerPartitionsIsNull() throws Exception {
+		ValidationUtil.validateCheckpointInterval( 100, null );
+		// ok
+	}
+
+	@Test
+	public void validateCheckpointInterval_lessThanRowsPerPartitions() throws Exception {
+		ValidationUtil.validateCheckpointInterval( 99, 100 );
+		// ok
+	}
+
+	@Test(expected = SearchException.class)
+	public void validateCheckpointInterval_equalToRowsPerPartitions() throws Exception {
+		ValidationUtil.validateCheckpointInterval( 100, 100 );
+	}
+
+	@Test(expected = SearchException.class)
+	public void validateCheckpointInterval_greaterThanRowsPerPartitions() throws Exception {
+		ValidationUtil.validateCheckpointInterval( 101, 100 );
+	}
+
+}


### PR DESCRIPTION
Hi Yoann,

Here's the PR for <https://hibernate.atlassian.net/browse/HSEARCH-2638>.

The main idea is to split the `checkpointInterval` validation into 2 cases:

- If user triggers the job manually via our params builder and configures both parameters `checkpointInterval` & `rowsPerPartition`, then we try to validate these parameters. In case of validation failure, an exception will be thrown because we don't allow the following case:

      checkpointInterval >= rowsPerPartition

- If user triggers the job via CLI / restarts the job / does not set params explicitly, then we think it's too late for triggering an exception (for a better user-experience). So instead of giving an exception, we give a warning log message at the very beginning of a job execution to tell user that the checkpointing won't work.