### PR TITLE
HSEARCH-2624 Add a "tenantId" parameter

### DIFF
--- a/jsr352/core/pom.xml
+++ b/jsr352/core/pom.xml
@@ -8,7 +8,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-search-jsr352-parent</artifactId>
@@ -16,7 +16,7 @@
     </parent>
 
     <artifactId>hibernate-search-jsr352-core</artifactId>
-    
+
     <name>Hibernate Search JSR-352</name>
     <description>Core of the Hibernate Search JSR-352 integration</description>
 
@@ -40,8 +40,23 @@
 
         <!-- test -->
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -69,7 +84,7 @@
             <artifactId>byteman-bmunit</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.ibm.jbatch</groupId>
             <artifactId>com.ibm.jbatch-runtime</artifactId>
@@ -79,7 +94,7 @@
         <!--
             JBatch requires a database in order to work, and it seems it uses SQL that won't work with H2.
             Anyway, it uses an embedded Derby instance by default, so we just put the Derby driver in the classpath
-            so it won't complain. 
+            so it won't complain.
          -->
         <dependency>
             <groupId>org.apache.derby</groupId>

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -106,6 +106,7 @@ public final class MassIndexingJob {
 		private Set<Criterion> customQueryCriteria;
 		private String customQueryHql;
 		private Integer customQueryLimit;
+		private String tenantId;
 
 		private ParametersBuilder(Class<?> entityType, Class<?>... entityTypes) {
 			if ( entityType == null ) {
@@ -308,6 +309,24 @@ public final class MassIndexingJob {
 		}
 
 		/**
+		 * Define the tenant ID for the job execution.
+		 *
+		 * @param tenantId Tenant ID. Null or empty value is not allowed.
+		 *
+		 * @return itself
+		 */
+		public ParametersBuilder tenantId(String tenantId) {
+			if ( tenantId == null ) {
+				throw new NullPointerException( "Your tenantId is null, please provide a valid tenant ID." );
+			}
+			if ( tenantId.isEmpty() ) {
+				throw new IllegalArgumentException( "Your tenantId is empty, please provide a valid tenant ID." );
+			}
+			this.tenantId = tenantId;
+			return this;
+		}
+
+		/**
 		 * Build the parameters.
 		 *
 		 * @return the parameters.
@@ -332,6 +351,7 @@ public final class MassIndexingJob {
 			addIfNotNull( jobParams, MassIndexingJobParameters.PURGE_ALL_ON_START, purgeAllOnStart );
 			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_TYPES, getEntityTypesAsString() );
 			addIfNotNull( jobParams, MassIndexingJobParameters.ROWS_PER_PARTITION, rowsPerPartition );
+			addIfNotNull( jobParams, MassIndexingJobParameters.TENANT_ID, tenantId );
 
 			if ( !customQueryCriteria.isEmpty() ) {
 				try {

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
@@ -43,4 +43,6 @@ public final class MassIndexingJobParameters {
 	public static final String CUSTOM_QUERY_CRITERIA = "customQueryCriteria";
 
 	public static final String CUSTOM_QUERY_LIMIT = "customQueryLimit";
+
+	public static final String TENANT_ID = "tenantId";
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/afterchunk/AfterChunkBatchlet.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/afterchunk/AfterChunkBatchlet.java
@@ -13,11 +13,11 @@ import javax.inject.Inject;
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.jsr352.logging.impl.Log;
 import org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters;
 import org.hibernate.search.jsr352.massindexing.impl.JobContextData;
+import org.hibernate.search.jsr352.massindexing.impl.util.PersistenceUtil;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
@@ -36,6 +36,10 @@ public class AfterChunkBatchlet extends AbstractBatchlet {
 	@BatchProperty(name = MassIndexingJobParameters.OPTIMIZE_ON_FINISH)
 	private String optimizeOnFinish;
 
+	@Inject
+	@BatchProperty(name = MassIndexingJobParameters.TENANT_ID)
+	private String tenantId;
+
 	private Session session;
 
 	@Override
@@ -45,7 +49,7 @@ public class AfterChunkBatchlet extends AbstractBatchlet {
 
 			JobContextData jobData = (JobContextData) jobContext.getTransientUserData();
 			EntityManagerFactory emf = jobData.getEntityManagerFactory();
-			session = emf.unwrap( SessionFactory.class ).openSession();
+			session = PersistenceUtil.openSession( emf, tenantId );
 			ContextHelper.getSearchIntegrator( session ).optimize();
 		}
 		return null;

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/beforechunk/BeforeChunkBatchlet.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/beforechunk/BeforeChunkBatchlet.java
@@ -13,13 +13,13 @@ import javax.inject.Inject;
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.jsr352.logging.impl.Log;
 import org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters;
 import org.hibernate.search.jsr352.massindexing.impl.JobContextData;
+import org.hibernate.search.jsr352.massindexing.impl.util.PersistenceUtil;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
@@ -42,6 +42,10 @@ public class BeforeChunkBatchlet extends AbstractBatchlet {
 	@BatchProperty(name = MassIndexingJobParameters.OPTIMIZE_AFTER_PURGE)
 	private String optimizeAfterPurge;
 
+	@Inject
+	@BatchProperty(name = MassIndexingJobParameters.TENANT_ID)
+	private String tenantId;
+
 	private Session session;
 	private FullTextSession fts;
 
@@ -50,7 +54,7 @@ public class BeforeChunkBatchlet extends AbstractBatchlet {
 		if ( Boolean.parseBoolean( this.purgeAllOnStart ) ) {
 			JobContextData jobData = (JobContextData) jobContext.getTransientUserData();
 			EntityManagerFactory emf = jobData.getEntityManagerFactory();
-			session = emf.unwrap( SessionFactory.class ).openSession();
+			session = PersistenceUtil.openSession( emf, tenantId );
 			fts = Search.getFullTextSession( session );
 			jobData.getEntityTypes().forEach( clz -> fts.purgeAll( clz ) );
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
@@ -33,6 +33,7 @@ import org.hibernate.search.jsr352.massindexing.impl.JobContextData;
 import org.hibernate.search.jsr352.massindexing.impl.util.JobContextUtil;
 import org.hibernate.search.jsr352.massindexing.impl.util.MassIndexingPartitionProperties;
 import org.hibernate.search.jsr352.massindexing.impl.util.PartitionBound;
+import org.hibernate.search.jsr352.massindexing.impl.util.PersistenceUtil;
 import org.hibernate.search.jsr352.massindexing.impl.util.SerializationUtil;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -106,6 +107,10 @@ public class EntityReader extends AbstractItemReader {
 	@Inject
 	@BatchProperty(name = MassIndexingJobParameters.CUSTOM_QUERY_LIMIT)
 	private String customQueryLimit;
+
+	@Inject
+	@BatchProperty(name = MassIndexingJobParameters.TENANT_ID)
+	private String tenantId;
 
 	@Inject
 	@BatchProperty(name = MassIndexingPartitionProperties.PARTITION_ID)
@@ -216,9 +221,9 @@ public class EntityReader extends AbstractItemReader {
 		log.printBound( bound );
 
 		emf = jobData.getEntityManagerFactory();
+		ss = PersistenceUtil.openStatelessSession( emf, tenantId );
+		session = PersistenceUtil.openSession( emf, tenantId );
 		sessionFactory = emf.unwrap( SessionFactory.class );
-		ss = sessionFactory.openStatelessSession();
-		session = sessionFactory.openSession();
 
 		PartitionContextData partitionData = null;
 		// HQL approach

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PersistenceUtil.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PersistenceUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.impl.util;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
+import org.hibernate.search.util.StringHelper;
+
+/**
+ * Internal utility class for persistence usage.
+ *
+ * @author Mincong Huang
+ */
+public final class PersistenceUtil {
+
+	private PersistenceUtil() {
+		// Private constructor, do not use it.
+	}
+
+	/**
+	 * Open a session with specific tenant ID. If the tenant ID argument is {@literal null} or empty, then a normal
+	 * session will be returned. The entity manager factory should be not null and opened when calling this method.
+	 *
+	 * @param entityManagerFactory entity manager factory
+	 * @param tenantId tenant ID, can be {@literal null} or empty.
+	 *
+	 * @return a new session
+	 */
+	public static Session openSession(EntityManagerFactory entityManagerFactory, String tenantId) {
+		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
+		Session session;
+		if ( StringHelper.isEmpty( tenantId ) ) {
+			session = sessionFactory.openSession();
+		}
+		else {
+			session = sessionFactory.withOptions()
+					.tenantIdentifier( tenantId )
+					.openSession();
+		}
+		return session;
+	}
+
+	/**
+	 * Open a stateless session with specific tenant ID. If the tenant ID argument is {@literal null} or empty, then a
+	 * normal stateless session will be returned. The entity manager factory should be not null and opened when calling
+	 * this method.
+	 *
+	 * @param entityManagerFactory entity manager factory
+	 * @param tenantId tenant ID, can be {@literal null} or empty.
+	 *
+	 * @return a new stateless session
+	 */
+	public static StatelessSession openStatelessSession(EntityManagerFactory entityManagerFactory, String tenantId) {
+		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
+		StatelessSession statelessSession;
+		if ( StringHelper.isEmpty( tenantId ) ) {
+			statelessSession = sessionFactory.openStatelessSession();
+		}
+		else {
+			statelessSession = sessionFactory.withStatelessOptions()
+					.tenantIdentifier( tenantId )
+					.openStatelessSession();
+		}
+		return statelessSession;
+	}
+
+}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/SerializationUtil.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/SerializationUtil.java
@@ -14,14 +14,11 @@ import java.io.ObjectOutputStream;
 import java.util.Base64;
 
 import org.hibernate.search.util.StringHelper;
-import org.jboss.logging.Logger;
 
 /**
  * @author Mincong Huang
  */
 public final class SerializationUtil {
-
-	public static final Logger LOGGER = Logger.getLogger( SerializationUtil.class );
 
 	private SerializationUtil() {
 		// Private constructor, do not use it.

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -30,13 +30,18 @@
             <properties>
                 <property name="optimizeAfterPurge" value="#{jobParameters['optimizeAfterPurge']}?:false;" />
                 <property name="purgeAllOnStart" value="#{jobParameters['purgeAllOnStart']}?:false;" />
+                <property name="tenantId" value="#{jobParameters['tenantId']}" />
             </properties>
         </batchlet>
     </step>
 
     <step id="produceLuceneDoc" next="afterChunk">
         <listeners>
-            <listener ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.StepProgressSetupListener" />
+            <listener ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.StepProgressSetupListener">
+                <properties>
+                    <property name="tenantId" value="#{jobParameters['tenantId']}" />
+                </properties>
+            </listener>
         </listeners>
         <chunk checkpoint-policy="custom">
             <reader ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.EntityReader">
@@ -46,9 +51,10 @@
 	                <property name="entityManagerFactoryReference" value="#{jobParameters['entityManagerFactoryReference']}" />
 	                <property name="entityTypes" value="#{jobParameters['entityTypes']}" />
 	                <property name="customQueryCriteria" value="#{jobParameters['customQueryCriteria']}" />
-	                
+
                     <property name="entityName" value="#{partitionPlan['entityName']}" />
                     <property name="partitionId" value="#{partitionPlan['partitionId']}" />
+                    <property name="tenantId" value="#{jobParameters['tenantId']}" />
                     <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:200000;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
@@ -58,6 +64,7 @@
             <processor ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.LuceneDocProducer">
                 <properties>
                     <property name="entityName" value="#{partitionPlan['entityName']}" />
+                    <property name="tenantId" value="#{jobParameters['tenantId']}" />
                 </properties>
             </processor>
             <writer ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.LuceneDocWriter">
@@ -75,6 +82,7 @@
         <partition>
             <mapper ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.PartitionMapper">
                 <properties>
+                    <property name="tenantId" value="#{jobParameters['tenantId']}" />
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:200000;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
                     <property name="maxThreads" value="#{jobParameters['maxThreads']}?:8;" />
@@ -90,6 +98,7 @@
         <batchlet ref="org.hibernate.search.jsr352.massindexing.impl.steps.afterchunk.AfterChunkBatchlet">
             <properties>
                 <property name="optimizeOnFinish" value="#{jobParameters['optimizeOnFinish']}?:false;" />
+                <property name="tenantId" value="#{jobParameters['tenantId']}" />
             </properties>
         </batchlet>
     </step>

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithMultiTenancyIT.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithMultiTenancyIT.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchStatus;
+import javax.batch.runtime.JobExecution;
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.Session;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.jsr352.massindexing.test.entity.Company;
+import org.hibernate.search.jsr352.test.util.JobFactory;
+import org.hibernate.search.jsr352.test.util.JobTestUtil;
+import org.hibernate.search.test.SearchTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.fest.util.Collections;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.search.jsr352.test.util.JobTestUtil.findIndexedResultsInTenant;
+
+/**
+ * @author Mincong Huang
+ */
+public class MassIndexingJobWithMultiTenancyIT extends SearchTestBase {
+
+	private static final String TARGET_TENANT_ID = "targetTenant";
+
+	private static final String UNUSED_TENANT_ID = "unusedTenant";
+
+	private static final int JOB_TIMEOUT_MS = 10_000;
+
+	private JobOperator jobOperator = JobFactory.getJobOperator();
+
+	private final List<Company> companies = Arrays.asList(
+			new Company( "Google" ),
+			new Company( "Red Hat" ),
+			new Company( "Microsoft" )
+	);
+
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		persist( TARGET_TENANT_ID, companies );
+		purgeAll( TARGET_TENANT_ID, Company.class );
+	}
+
+	private <T> void persist(String tenantId, List<T> entities) {
+		try (Session session = openSessionWithTenantId( tenantId )) {
+			session.getTransaction().begin();
+			entities.forEach( session::persist );
+			session.getTransaction().commit();
+		}
+	}
+
+	private void purgeAll(String tenantId, Class<?> entityType) throws IOException {
+		FullTextSession session = Search.getFullTextSession( openSessionWithTenantId( tenantId ) );
+		session.purgeAll( entityType );
+		session.flushToIndexes();
+		session.close();
+	}
+
+	@Test
+	public void shouldHandleTenantIds() throws Exception {
+		long executionId = jobOperator.start(
+				MassIndexingJob.NAME,
+				MassIndexingJob.parameters()
+						.forEntity( Company.class )
+						.tenantId( TARGET_TENANT_ID )
+						.build()
+		);
+
+		JobExecution jobExecution = jobOperator.getJobExecution( executionId );
+		JobTestUtil.waitForTermination( jobOperator, jobExecution, JOB_TIMEOUT_MS );
+		assertThat( jobExecution.getBatchStatus() ).isEqualTo( BatchStatus.COMPLETED );
+
+		EntityManagerFactory emf = getSessionFactory().unwrap( EntityManagerFactory.class );
+
+		assertThat( findIndexedResultsInTenant( emf, Company.class, "name", "Google", TARGET_TENANT_ID ) ).hasSize( 1 );
+		assertThat( findIndexedResultsInTenant( emf, Company.class, "name", "Red Hat", TARGET_TENANT_ID ) ).hasSize( 1 );
+		assertThat( findIndexedResultsInTenant( emf, Company.class, "name", "Microsoft", TARGET_TENANT_ID ) ).hasSize( 1 );
+
+		assertThat( findIndexedResultsInTenant( emf, Company.class, "name", "Google", UNUSED_TENANT_ID ) ).isEmpty();
+		assertThat( findIndexedResultsInTenant( emf, Company.class, "name", "Red Hat", UNUSED_TENANT_ID ) ).isEmpty();
+		assertThat( findIndexedResultsInTenant( emf, Company.class, "name", "Microsoft", UNUSED_TENANT_ID ) ).isEmpty();
+	}
+
+	private Session openSessionWithTenantId(String tenantId) {
+		return getSessionFactory().withOptions().tenantIdentifier( tenantId ).openSession();
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Company.class };
+	}
+
+	@Override
+	public Set<String> multiTenantIds() {
+		return Collections.set( TARGET_TENANT_ID, UNUSED_TENANT_ID );
+	}
+
+	@Override
+	public void configure(Map<String, Object> cfg) {
+		cfg.put( "hibernate.search.indexing_strategy", "manual" );
+	}
+
+}

--- a/jsr352/core/src/test/resources/log4j.properties
+++ b/jsr352/core/src/test/resources/log4j.properties
@@ -1,0 +1,54 @@
+### direct log messages to stdout ###
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
+
+### direct messages to file hibernate.log ###
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.File=hibernate.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
+
+### direct messages to socket - chainsaw ###
+log4j.appender.socket=org.apache.log4j.net.SocketAppender
+log4j.appender.socket.remoteHost=localhost
+log4j.appender.socket.port=4560
+log4j.appender.socket.locationInfo=true
+
+### set log levels - for more verbose logging change 'info' to 'debug' ###
+
+log4j.rootLogger=info, stdout
+log4j.logger.org.jboss=info
+#log4j.logger.com.jboss=debug
+
+log4j.logger.org.hibernate=warn
+
+log4j.logger.org.hibernate.search=debug
+#log4j.logger.org.hibernate.search.backend=debug
+
+### log just the SQL
+#log4j.logger.org.hibernate.SQL=debug
+
+#log4j.logger.org.hibernate.engine.CascadingAction=debug
+
+### log JDBC bind parameters ###
+#log4j.logger.org.hibernate.type=debug
+
+### log schema export/update ###
+log4j.logger.org.hibernate.tool.hbm2ddl=warn
+
+### log cache activity ###
+#log4j.logger.org.hibernate.cache=debug
+
+### enable the following line if you want to track down connection ###
+### leakages when using DriverManagerConnectionProvider ###
+#log4j.logger.org.hibernate.connection.DriverManagerConnectionProvider=trace
+
+### annotation logs
+#log4j.logger.org.hibernate.annotation=info
+#log4j.logger.org.hibernate.cfg=info
+#log4j.logger.org.hibernate.cfg.SettingsFactory=info
+#log4j.logger.org.hibernate.cfg.AnnotationBinder=info
+#log4j.logger.org.hibernate.cfg.AnnotationConfiguration=info
+#log4j.logger.org.hibernate.cfg.Ejb3Column=info

--- a/jsr352/pom.xml
+++ b/jsr352/pom.xml
@@ -72,6 +72,13 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-orm</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
Please do not merge this PR.

I'm currently blocked with the code configuration. When implementing the multi-tenancy methods, the following method has always been skipped automatically:

    MassIndexingJobWithMultiTenancyTest#shouldHandleTenantIds

I spent many time on it and still cannot find why... Please help.