### PR TITLE
HSEARCH-2621 Add integration tests using a different JSR-352 implementation

### DIFF
--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/MultipleEntityManagerFactoriesNotRegisteredAsBeansIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/MultipleEntityManagerFactoriesNotRegisteredAsBeansIT.java
@@ -28,14 +28,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * This integration test (IT) aims to test the restartability of the job execution mass-indexer under Java EE
- * environment, with step partitioning (parallelism). We need to prove that the job restart from the checkpoint where it
- * was stopped, but not from the very beginning.
+ * Test the behavior when there are multiple entity manager factories (persistence units),
+ * and they haven't been registered as CDI beans.
  *
  * @author Mincong Huang
  */
 @RunWith(Arquillian.class)
-public class MultiplePersistenceUnitsIT {
+public class MultipleEntityManagerFactoriesNotRegisteredAsBeansIT {
 
 	private static final String PERSISTENCE_UNIT_NAME = "h2";
 
@@ -44,7 +43,7 @@ public class MultiplePersistenceUnitsIT {
 	@Deployment
 	public static WebArchive createDeployment() {
 		WebArchive war = ShrinkWrap
-				.create( WebArchive.class, MultiplePersistenceUnitsIT.class.getSimpleName() + ".war" )
+				.create( WebArchive.class, MultipleEntityManagerFactoriesNotRegisteredAsBeansIT.class.getSimpleName() + ".war" )
 				.addAsResource( "jsr352/persistence_multiple.xml", "META-INF/persistence.xml" )
 				.addAsResource( "jsr352/make-deployment-as-batch-app.xml", "META-INF/batch-jobs/make-deployment-as-batch-app.xml" ) // WFLY-7000
 				.addAsWebInfResource( "jboss-deployment-structure-jsr352.xml", "/jboss-deployment-structure.xml" )

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/MultipleEntityManagerFactoriesRegisteredAsBeansIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/MultipleEntityManagerFactoriesRegisteredAsBeansIT.java
@@ -37,15 +37,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 
 /**
- * This integration test (IT) aims to test the restartability of the job execution mass-indexer under Java EE
- * environment, with step partitioning (parallelism). We need to prove that the job restart from the checkpoint where it
- * was stopped, but not from the very beginning.
+ * Test the behavior when there are multiple entity manager factories (persistence units),
+ * but those are correctly registered as CDI beans.
  *
  * @author Mincong Huang
  */
 @RunWith(Arquillian.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class MultipleEntityManagerFactoryBeansIT {
+public class MultipleEntityManagerFactoriesRegisteredAsBeansIT {
 
 	private static final String ENTITY_MANAGER_FACTORY_BEAN_NAME = MultipleEntityManagerFactoriesProducer.H2_ENTITY_MANAGER_FACTORY_BEAN_NAME;
 
@@ -61,7 +60,7 @@ public class MultipleEntityManagerFactoryBeansIT {
 	@Deployment
 	public static WebArchive createDeployment() {
 		WebArchive war = ShrinkWrap
-				.create( WebArchive.class, MultipleEntityManagerFactoryBeansIT.class.getSimpleName() + ".war" )
+				.create( WebArchive.class, MultipleEntityManagerFactoriesRegisteredAsBeansIT.class.getSimpleName() + ".war" )
 				.addAsResource( "jsr352/persistence_multiple.xml", "META-INF/persistence.xml" )
 				.addAsResource( "jsr352/make-deployment-as-batch-app.xml", "META-INF/batch-jobs/make-deployment-as-batch-app.xml" ) // WFLY-7000
 				.addAsWebInfResource( "jboss-deployment-structure-jsr352.xml", "/jboss-deployment-structure.xml" )

--- a/jsr352/core/pom.xml
+++ b/jsr352/core/pom.xml
@@ -70,56 +70,21 @@
             <scope>test</scope>
         </dependency>
         
-        <!-- The JBeret artifacts declare all the dependencies as provided, so we have to redeclare them ourselves... -->
-        <!-- JBeret minimal application dependencies -->
-        <!-- https://jberet.gitbooks.io/jberet-user-guide/content/set_up_jberet/#minimal-application-dependencies -->
         <dependency>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <groupId>com.ibm.jbatch</groupId>
+            <artifactId>com.ibm.jbatch-runtime</artifactId>
+            <version>1.0</version>
             <scope>test</scope>
         </dependency>
+        <!--
+            JBatch requires a database in order to work, and it seems it uses SQL that won't work with H2.
+            Anyway, it uses an embedded Derby instance by default, so we just put the Derby driver in the classpath
+            so it won't complain. 
+         -->
         <dependency>
-            <groupId>org.jberet</groupId>
-            <artifactId>jberet-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.marshalling</groupId>
-            <artifactId>jboss-marshalling</artifactId>
-            <version>1.4.11.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core</artifactId>
-            <version>2.3.4.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
-            <version>1.1.2.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-            <scope>test</scope>
-        </dependency>
-        
-        <!-- The JBeret artifacts declare all the dependencies as provided, so we have to redeclare them ourselves... -->
-        <!-- Additional dependencies for Java SE batch applications -->
-        <!-- https://jberet.gitbooks.io/jberet-user-guide/content/set_up_jberet/#additional-dependencies-for-java-se-batch-applications -->
-        <dependency>
-            <groupId>org.jberet</groupId>
-            <artifactId>jberet-se</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se</artifactId>
-            <version>2.3.4.Final</version>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.13.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jsr352/core/src/test/resources/META-INF/services/batch-config.properties
+++ b/jsr352/core/src/test/resources/META-INF/services/batch-config.properties
@@ -1,0 +1,6 @@
+# Let JBatch use an embedded Derby database (the default),
+# since the SQL it generates doesn't seem to work on other DBs (H2 in particular)
+
+# However, we still customize the database location
+# (the default uses a "RUNTIMEDB" directory in the current working directory)
+JDBC_URL=jdbc:derby:memory:jbatch;create=true

--- a/jsr352/core/src/test/resources/META-INF/services/batch-services.properties
+++ b/jsr352/core/src/test/resources/META-INF/services/batch-services.properties
@@ -1,0 +1,1 @@
+J2SE_MODE=true


### PR DESCRIPTION
**Don't merge yet**: this PR is based on https://github.com/yrodiere/hibernate-search/pull/11 (HSEARCH-2689), which should be merged first.

Relevant JIRA ticket: https://hibernate.atlassian.net/browse/HSEARCH-2621

I chose to simply switch to JBatch for our integration tests in jsr352-core, since we already test JBeret in our WildFly integration tests.