### PR TITLE
HSEARCH-2708 JSR-352: Change the mass indexing job ID following the recent job renaming

### DIFF
--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -5,7 +5,7 @@
  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
   -->
-<job id="BatchIndexingJob" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<job id="hibernate-search-mass-indexing" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" version="1.0">
 
     <listeners>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2708

Just a quick fix. Will merge as soon as the build passes.