### PR TITLE
HSEARCH-2611 Transaction timeout issues

### DIFF
--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/MassIndexingJobTransactionTimeoutIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/MassIndexingJobTransactionTimeoutIT.java
@@ -1,0 +1,109 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.integration.jsr352.massindexing;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchRuntime;
+import javax.batch.runtime.BatchStatus;
+import javax.batch.runtime.JobExecution;
+import javax.inject.Inject;
+
+import org.hibernate.search.jsr352.massindexing.MassIndexingJob;
+import org.hibernate.search.jsr352.test.util.JobTestUtil;
+import org.hibernate.search.test.integration.wildfly.massindexing.Concert;
+import org.hibernate.search.test.integration.wildfly.massindexing.ConcertManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Mincong Huang
+ */
+@RunWith(Arquillian.class)
+public class MassIndexingJobTransactionTimeoutIT {
+
+	private static final int JOB_TIMEOUT_MS = 10_000;
+
+	private static final int CONCERT_COUNT = 5_000;
+
+	@Inject
+	private ConcertManager concertManager;
+
+	@Deployment
+	public static Archive<?> createTestArchive() {
+		return ShrinkWrap
+				.create( WebArchive.class, MassIndexingJobTransactionTimeoutIT.class.getSimpleName() + ".war" )
+				.addAsResource( "jsr352/persistence.xml", "META-INF/persistence.xml" )
+				.addAsResource( "jsr352/make-deployment-as-batch-app.xml", "META-INF/batch-jobs/make-deployment-as-batch-app.xml" ) // WFLY-7000
+				.addAsWebInfResource( "jboss-deployment-structure-jsr352.xml", "/jboss-deployment-structure.xml" )
+				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
+				.addPackage( JobTestUtil.class.getPackage() )
+				.addPackage( Concert.class.getPackage() );
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		List<Concert> concerts = new LinkedList<>();
+		for ( int i = 0; i < CONCERT_COUNT; i++ ) {
+			Date now = new Date( System.currentTimeMillis() );
+			concerts.add( new Concert( "An artist", now ) );
+		}
+		concertManager.saveConcerts( concerts );
+		Concert.SLOW_DOWN = true;
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		Concert.SLOW_DOWN = false;
+	}
+
+	/**
+	 * When the transaction timeout property, {@code javax.transaction.global.timeout},
+	 * is assigned with a short value, the mass indexing job won't have enough time to
+	 * finish the indexation.
+	 */
+	@Test
+	public void jobFailsWhenTimeoutIsShort() throws Exception {
+		JobOperator jobOperator = BatchRuntime.getJobOperator();
+		Properties properties = MassIndexingJob.parameters()
+				.forEntity( Concert.class )
+				.rowsPerPartition( CONCERT_COUNT )
+				.transactionTimeout( 2, TimeUnit.SECONDS )
+				.build();
+		long executionId = jobOperator.start( MassIndexingJob.NAME, properties );
+
+		JobExecution jobExecution = jobOperator.getJobExecution( executionId );
+		JobTestUtil.waitForTermination( jobOperator, jobExecution, JOB_TIMEOUT_MS );
+
+		/*
+		 * The result cannot be BatchStatus.COMPLETED, because the transaction timeout
+		 * value is too short for the job execution to complete its mission. However,
+		 * the batch status cannot be determined as BatchStatus.FAILED neither, because
+		 * the JobTestUtil might not have waited enough time to let the batch runtime
+		 * return a correct result. So instead of asserting a determinist status, we
+		 * only assert that the status cannot be BatchStatus.COMPLETED.
+		 */
+		assertFalse( jobExecution.getBatchStatus() == BatchStatus.COMPLETED );
+	}
+
+}

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/test/common/MessageManager.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/test/common/MessageManager.java
@@ -49,6 +49,7 @@ public class MessageManager {
 	}
 
 	@SuppressWarnings("unchecked")
+	@TransactionTimeout(value = 5, unit = TimeUnit.MINUTES)
 	public List<Message> findMessagesFor(Date date) {
 		FullTextEntityManager ftem = Search.getFullTextEntityManager( em );
 		Date dateDay = DateTools.round( date, DateTools.Resolution.DAY );

--- a/integrationtest/wildfly/src/wildflyConfig/standalone/configuration/standalone-full-testqueues.xml
+++ b/integrationtest/wildfly/src/wildflyConfig/standalone/configuration/standalone-full-testqueues.xml
@@ -391,8 +391,7 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
 
             <!-- TX timeout of 2 sec is required by MassIndexingTimeoutIT -->
-            <!-- TX timeout of 300 sec is required by the batch job "mass-index" -->
-            <coordinator-environment default-timeout="300"/>
+            <coordinator-environment default-timeout="2"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:undertow:3.0">
             <buffer-cache name="default"/>

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.hibernate.Criteria;
@@ -107,6 +108,7 @@ public final class MassIndexingJob {
 		private String customQueryHql;
 		private Integer customQueryLimit;
 		private String tenantId;
+		private Integer transactionTimeoutInSecond;
 
 		private ParametersBuilder(Class<?> entityType, Class<?>... entityTypes) {
 			if ( entityType == null ) {
@@ -327,6 +329,32 @@ public final class MassIndexingJob {
 		}
 
 		/**
+		 * Define the transaction timeout for entity indexing, which will be applied each partition of the indexation
+		 * step.
+		 * <p>
+		 * Spec 1.0, §9.7 Transactionality:
+		 * <br>
+		 * Chunk type check points are transactional. The batch runtime uses global transaction mode on the Java EE
+		 * platform and local transaction mode on the Java SE platform. Global transaction timeout is configurable at
+		 * step-level with a step-level property (default is 180 seconds):
+		 * <pre>
+		 * javax.transaction.global.timeout={seconds}
+		 * </pre>
+		 *
+		 * @param value The transaction timeout value, which must be 0 (no-timeout) or positive value.
+		 * @param unit The time-unit of the value.
+		 *
+		 * @return itself
+		 */
+		public ParametersBuilder transactionTimeout(int value, TimeUnit unit) {
+			if ( value < 0 ) {
+				throw new IllegalArgumentException( "Transaction timeout must be 0 (no-timeout) or positive value." );
+			}
+			transactionTimeoutInSecond = (int) unit.toSeconds( value );
+			return this;
+		}
+
+		/**
 		 * Build the parameters.
 		 *
 		 * @return the parameters.
@@ -352,6 +380,7 @@ public final class MassIndexingJob {
 			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_TYPES, getEntityTypesAsString() );
 			addIfNotNull( jobParams, MassIndexingJobParameters.ROWS_PER_PARTITION, rowsPerPartition );
 			addIfNotNull( jobParams, MassIndexingJobParameters.TENANT_ID, tenantId );
+			addIfNotNull( jobParams, MassIndexingJobParameters.TRANSACTION_TIMEOUT_IN_SECOND, transactionTimeoutInSecond );
 
 			if ( !customQueryCriteria.isEmpty() ) {
 				try {

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
@@ -45,4 +45,7 @@ public final class MassIndexingJobParameters {
 	public static final String CUSTOM_QUERY_LIMIT = "customQueryLimit";
 
 	public static final String TENANT_ID = "tenantId";
+
+	public static final String TRANSACTION_TIMEOUT_IN_SECOND = "javax.transaction.global.timeout";
+
 }

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -41,6 +41,10 @@
     </step>
 
     <step id="produceLuceneDoc" next="afterChunk">
+        <properties>
+            <!-- In seconds -->
+            <property name="javax.transaction.global.timeout" value="#{jobParameters['javax.transaction.global.timeout']}?:180;" />
+        </properties>
         <listeners>
             <listener ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.StepProgressSetupListener">
                 <properties>


### PR DESCRIPTION
Hi @yrodiere & @Sanne,

This is PR for [HSEARCH-2611](https://hibernate.atlassian.net/browse/HSEARCH-2611). By sending this request, I want to have a discussion about the transaction timeout with you, but I don't expect that we can merge it right now. Actually I'm not very sure what should be addressed, and how to handle it. The origin issue https://github.com/mincong-h/gsoc-hsearch/issues/113 was vague for me too... For what I understand, there're at least 2 kinds of transaction timeouts:

- [Stack Overflow - Query Timeout in EntityManager](https://stackoverflow.com/questions/24244621/set-timeout-on-entitymanager-query)
- [Stack Overflow - Step Timeout in JSR-352](https://stackoverflow.com/questions/36945450/how-do-i-configure-a-transaction-timeout-in-websphere-liberty-batch)

I'm not sure if they're what I should handled, and if there's anything else. So I'm want to discuss with you what to do first.

Have a nice week!