### PR TITLE
HSEARCH-2758 JSR-352: Fix incorrect indexing progress monitor

### DIFF
--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
@@ -30,6 +30,7 @@ import org.hibernate.search.test.integration.jsr352.massindexing.test.common.Mes
 import org.hibernate.search.test.integration.jsr352.massindexing.test.common.MessageManager;
 import org.hibernate.search.test.integration.jsr352.massindexing.test.util.JobInterruptorUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -78,6 +79,7 @@ public class RestartIT {
 	}
 
 	@Before
+	@RunAsClient
 	public void insertData() throws ParseException {
 		List<Message> messages = new LinkedList<>();
 		for ( int i = 0; i < DB_DAY1_ROWS; i++ ) {
@@ -90,6 +92,7 @@ public class RestartIT {
 	}
 
 	@After
+	@RunAsClient
 	public void removeAll() {
 		messageManager.removeAll();
 	}

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
@@ -116,6 +116,8 @@ public class RestartIT {
 		jobExec1 = JobTestUtil.waitForTermination( jobOperator, jobExec1, JOB_TIMEOUT_MS );
 		JobInterruptorUtil.disable();
 
+		assertEquals( BatchStatus.FAILED, jobExec1.getBatchStatus() );
+
 		// Restart the job. This is the 2nd execution.
 		long execId2 = jobOperator.restart( execId1, null );
 		JobExecution jobExec2 = jobOperator.getJobExecution( execId2 );
@@ -145,6 +147,8 @@ public class RestartIT {
 		JobExecution jobExec1 = jobOperator.getJobExecution( execId1 );
 		jobExec1 = JobTestUtil.waitForTermination( jobOperator, jobExec1, JOB_TIMEOUT_MS );
 		JobInterruptorUtil.disable();
+
+		assertEquals( BatchStatus.FAILED, jobExec1.getBatchStatus() );
 
 		// Restart the job. This is the 2nd execution.
 		long execId2 = jobOperator.restart( execId1, null );


### PR DESCRIPTION
### Problem

As mentioned in the ticket [HSEARCH-2758](https://hibernate.atlassian.net/browse/HSEARCH-2758), the monitor was wrong about the indexing progress. It ended up with more than 2100%, which is 21 times higher than expected:

```
org.hibernate.search.test.integration.jsr352.massindexing.test.common.Message: 105001/5000 works processed (2100.02%).
```

### Solution

See <https://github.com/yrodiere/hibernate-search/pull/19>