### PR TITLE
HSEARCH-2731 Setup performance tests for JSR-352

### DIFF
--- a/integrationtest/jsr352-performance/pom.xml
+++ b/integrationtest/jsr352-performance/pom.xml
@@ -70,6 +70,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
         </dependency>

--- a/integrationtest/jsr352-performance/src/test/resources/arquillian.xml
+++ b/integrationtest/jsr352-performance/src/test/resources/arquillian.xml
@@ -22,6 +22,7 @@
                 <property name="jbossHome">${project.build.directory}/node1/wildfly-${wildflyVersion}</property>
                 <!-- Needed for JMS tests -->
                 <property name="serverConfig">standalone-full-testqueues.xml</property>
+                <property name="javaVmArguments">-Dorg.hibernate.search.enable_performance_tests=${org.hibernate.search.enable_performance_tests}</property>
                 <!-- To debug the Arquillian managed application server: -->
                 <!-- property name="javaVmArguments">
                     -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y 


### PR DESCRIPTION
## Module hibernate-search-jsr352-performance

Hi @yrodiere, 

Here's the PR for <https://hibernate.atlassian.net/browse/HSEARCH-2731>.

After having rebased branch `yrodiere/jsr352` on the latest `hibernate/master`, the problem of performance test enablement should have been fixed: the Maven property has been transmitted to failsafe plugin to make it recognizable as JVM property.

But it's not that simple, because our performance test `PerformanceIT` runs in Arquillian. Arquillian ITs run in another JVM, which is an Arquillian-managed container. **Therefore, the property needed to be passed via `arquillian.xml`, as part of the JVM arguments.**

I tested the module `hibernate-search-jsr352-performance` with the following commands, and they worked:

```
mvn clean verify
mvn clean verify -Pperf
mvn clean verify -Dorg.hibernate.search.enable_performance_tests=true
mvn clean verify -Dorg.hibernate.search.enable_performance_tests=false
```

## Module hibernate-search-integrationtest-wildfly

I'm not sure if I should do the same performance tests setup in module `hibernate-search-integrationtest-wildfly`, where we've a package for JSR-352 tests `org.hibernate.search.test.integration.jsr352.massindexing`.

The pro is by enabling such property, we can make the tests run faster by default; and test the performance of every JSR-352 scenarios (restart-ability, multi-entity-manager-factory, etc).

The con is that it requires much more additional work. We need to setup an exact scenario for the classical `MassIndexer` for each existing test, then compare the timing between `MassIndexer` & JSR-352 job; we will also need to modify the Byteman script, because the restart point is hard-coded, it must be changed according to the performance enablement.

My opinion is not to do it for the moment, to gain more time for other important tickets.