### PR TITLE
HSEARCH-2615 Embedded ID is not well handled

### DIFF
--- a/integrationtest/jsr352-performance/src/test/java/org/hibernate/search/jsr352/massindexing/PerformanceIT.java
+++ b/integrationtest/jsr352-performance/src/test/java/org/hibernate/search/jsr352/massindexing/PerformanceIT.java
@@ -24,10 +24,12 @@ import org.hibernate.CacheMode;
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.Search;
 import org.hibernate.search.jsr352.logging.impl.Log;
+import org.hibernate.search.jsr352.massindexing.test.bridge.DateIdBridge;
 import org.hibernate.search.jsr352.massindexing.test.entity.Company;
 import org.hibernate.search.jsr352.massindexing.test.entity.CompanyManager;
 import org.hibernate.search.jsr352.massindexing.test.entity.Person;
 import org.hibernate.search.jsr352.massindexing.test.entity.PersonManager;
+import org.hibernate.search.jsr352.massindexing.test.id.DatePK;
 import org.hibernate.search.jsr352.test.util.JobTestUtil;
 import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -84,6 +86,8 @@ public class PerformanceIT {
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
 				.addPackage( TestConstants.class.getPackage() )
 				.addPackage( JobTestUtil.class.getPackage() )
+				.addPackage( DatePK.class.getPackage() )
+				.addPackage( DateIdBridge.class.getPackage() )
 				.addPackage( Company.class.getPackage() );
 		return war;
 	}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
@@ -322,8 +322,7 @@ public class EntityReader extends AbstractItemReader {
 				.scroll( ScrollMode.FORWARD_ONLY );
 	}
 
-	private static void applyBound(Criteria criteria,
-			IdOrder idOrder, PartitionBound partitionBound) throws Exception {
+	private static void applyBound(Criteria criteria, IdOrder idOrder, PartitionBound partitionBound) {
 		if ( partitionBound.hasUpperBound() ) {
 			Object upperBound = partitionBound.getUpperBound();
 			criteria.add( idOrder.idLesser( upperBound ) );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/LuceneDocProducer.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/LuceneDocProducer.java
@@ -83,7 +83,7 @@ public class LuceneDocProducer implements ItemProcessor {
 	 */
 	private void setup() throws ClassNotFoundException, NamingException {
 		JobContextData jobContextData = (JobContextData) jobContext.getTransientUserData();
-		Class<?> entityType = jobContextData.getIndexedType( entityName );
+		Class<?> entityType = jobContextData.getEntityType( entityName );
 		entityTypeIdentifier = new PojoIndexedTypeIdentifier( entityType );
 		searchIntegrator = jobContextData.getSearchIntegrator();
 		entityIndexBinding = searchIntegrator.getIndexBindings().get( entityTypeIdentifier );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/LuceneDocWriter.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/LuceneDocWriter.java
@@ -66,7 +66,7 @@ public class LuceneDocWriter extends AbstractItemWriter {
 
 		JobContextData jobData = (JobContextData) jobContext.getTransientUserData();
 
-		Class<?> entityType = jobData.getIndexedType( entityName );
+		Class<?> entityType = jobData.getEntityType( entityName );
 		entityIndexBinding = jobData.getSearchIntegrator()
 				.getIndexBinding( entityType );
 	}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/CompositeIdOrder.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/CompositeIdOrder.java
@@ -32,6 +32,21 @@ import org.hibernate.type.ComponentType;
  * e.g. an entity annotated {@link IdClass}, or an entity having an
  * {@link EmbeddedId}.
  *
+ * <h4>Why this class?</h4>
+ * By default, {@code Restrictions.ge} and similar on
+ * a composite property will generate a non-lexicographical "greater or equal" condition.
+ * <p>
+ * For instance, a condition such as
+ * {@code Restrictions.ge("myEmbeddedDate", MyEmbeddedDate.yearMonthDay( 2017, 6, 20 )}
+ * will generate {@code year >= 2017 AND month >= 6 AND day >= 20}
+ * which is obviously not what any sane person would expect,
+ * since this will exclude July 1st to July 19th (among others).
+ * <p>
+ * This class fixes the issue by properly implementing lexicographical
+ * "greater or equal" and "lesser" conditions.
+ *
+ * @see <a href="https://hibernate.atlassian.net/browse/HSEARCH-2615">HSEARCH-2615</a>
+ *
  * @author Mincong Huang
  * @author Yoann Rodiere
  */

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/CompositeIdOrder.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/CompositeIdOrder.java
@@ -1,0 +1,103 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.impl.util;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.IdClass;
+import javax.persistence.metamodel.SingularAttribute;
+
+import org.hibernate.Criteria;
+import org.hibernate.criterion.Conjunction;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
+import org.hibernate.search.util.impl.CollectionHelper;
+
+/**
+ * Order over multiple ID attributes.
+ * <p>
+ * This class should be used when target entity has multiple ID attributes,
+ * e.g. an entity annotated {@link IdClass}, or an entity having an
+ * {@link EmbeddedId}.
+ *
+ * @author Mincong Huang
+ * @author Yoann Rodiere
+ */
+public class CompositeIdOrder implements IdOrder {
+
+	private final String prefix;
+
+	private final List<String> idAttributeNames;
+
+	public CompositeIdOrder(String prefix, Collection<? extends SingularAttribute<?, ?>> idAttributes) {
+		super();
+		this.prefix = prefix;
+		this.idAttributeNames = CollectionHelper.newArrayList( idAttributes.size() );
+		for ( SingularAttribute<?, ?> idAttribute : idAttributes ) {
+			String name = idAttribute.getName();
+			idAttributeNames.add( name );
+		}
+		idAttributeNames.sort( Comparator.naturalOrder() );
+
+	}
+
+	@Override
+	public Criterion idGreaterOrEqual(Object idObj) throws Exception {
+		return restrictLexicographically( Restrictions::ge, idObj );
+	}
+
+	@Override
+	public Criterion idLesser(Object idObj) throws Exception {
+		return restrictLexicographically( Restrictions::lt, idObj );
+	}
+
+	@Override
+	public void addAscOrder(Criteria criteria) {
+		for ( String name : idAttributeNames ) {
+			criteria.addOrder( Order.asc( prefix + name ) );
+		}
+	}
+
+	private Criterion restrictLexicographically(BiFunction<String, Object, SimpleExpression> lastRestriction, Object idObj)
+			throws InvocationTargetException, IllegalAccessException, IntrospectionException {
+		Conjunction[] or = new Conjunction[idAttributeNames.size()];
+
+		for ( int i = 0; i < or.length; i++ ) {
+			// Group expressions together in a single conjunction (A and B and C...).
+			SimpleExpression[] and = new SimpleExpression[i + 1];
+			int j = 0;
+			for ( ; j < and.length - 1; j++ ) {
+				// The first N-1 expressions have symbol `=`
+				String key = idAttributeNames.get( j );
+				Object val = getPropertyValue( idObj, key );
+				and[j] = Restrictions.eq( prefix + key, val );
+			}
+			// The last expression has whatever symbol is defined by "lastRestriction"
+			String key = idAttributeNames.get( j );
+			Object val = getPropertyValue( idObj, key );
+			and[j] = lastRestriction.apply( prefix + key, val );
+
+			or[i] = Restrictions.conjunction( and );
+		}
+		// Group the disjunction of multiple expressions (X or Y or Z...).
+		return Restrictions.or( or );
+	}
+
+	private static Object getPropertyValue(Object obj, String propertyName)
+			throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+		return new PropertyDescriptor( propertyName, obj.getClass() ).getReadMethod().invoke( obj );
+	}
+}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/EntityTypeDescriptor.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/EntityTypeDescriptor.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.impl.util;
+
+
+/**
+ * @author Yoann Rodiere
+ */
+public class EntityTypeDescriptor {
+
+	private final Class<?> javaClass;
+
+	private final IdOrder idOrder;
+
+	public EntityTypeDescriptor(Class<?> javaClass, IdOrder idOrder) {
+		super();
+		this.javaClass = javaClass;
+		this.idOrder = idOrder;
+	}
+
+	public Class<?> getJavaClass() {
+		return javaClass;
+	}
+
+	public IdOrder getIdOrder() {
+		return idOrder;
+	}
+
+}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/IdOrder.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/IdOrder.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.impl.util;
+
+import org.hibernate.Criteria;
+import org.hibernate.criterion.Criterion;
+
+/**
+ * Provides ID-based, order-sensitive restrictions
+ * and ascending ID order for the indexed type,
+ * allowing to easily build partitions based on ID order.
+ *
+ * @author Mincong Huang
+ * @author Yoann Rodiere
+ */
+public interface IdOrder {
+
+	/**
+	 * @param idObj The ID all results should be greater than or equal to.
+	 * @return A "greater or equal" restriction on the ID.
+	 * @throws Exception
+	 */
+	Criterion idGreaterOrEqual(Object idObj) throws Exception;
+
+	/**
+	 * @param idObj The ID all results should be lesser than.
+	 * @return A "lesser than" restriction on the ID.
+	 * @throws Exception
+	 */
+	Criterion idLesser(Object idObj) throws Exception;
+
+	void addAscOrder(Criteria criteria);
+
+}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/IdOrder.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/IdOrder.java
@@ -22,16 +22,14 @@ public interface IdOrder {
 	/**
 	 * @param idObj The ID all results should be greater than or equal to.
 	 * @return A "greater or equal" restriction on the ID.
-	 * @throws Exception
 	 */
-	Criterion idGreaterOrEqual(Object idObj) throws Exception;
+	Criterion idGreaterOrEqual(Object idObj);
 
 	/**
 	 * @param idObj The ID all results should be lesser than.
 	 * @return A "lesser than" restriction on the ID.
-	 * @throws Exception
 	 */
-	Criterion idLesser(Object idObj) throws Exception;
+	Criterion idLesser(Object idObj);
 
 	void addAscOrder(Criteria criteria);
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/JobContextUtil.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/JobContextUtil.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.jsr352.massindexing.impl.util;
 
+import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_CRITERIA;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,8 +30,6 @@ import org.hibernate.search.jsr352.logging.impl.Log;
 import org.hibernate.search.jsr352.massindexing.impl.JobContextData;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
-
-import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_CRITERIA;
 
 /**
  * Utility allowing to set up and retrieve the job context data, shared by all the steps.
@@ -104,6 +104,8 @@ public final class JobContextUtil {
 				.filter( clz -> entityNamesToIndex.contains( clz.getName() ) )
 				.collect( Collectors.toCollection( HashSet::new ) );
 
+		List<EntityTypeDescriptor> descriptors = PersistenceUtil.createDescriptors( emf, entityTypesToIndex );
+
 		@SuppressWarnings("unchecked")
 		Set<Criterion> criteria = SerializationUtil.parseParameter( Set.class, CUSTOM_QUERY_CRITERIA, serializedCustomQueryCriteria );
 		if ( criteria == null ) {
@@ -114,7 +116,7 @@ public final class JobContextUtil {
 		JobContextData jobContextData = new JobContextData();
 		jobContextData.setEntityManagerFactory( emf );
 		jobContextData.setCustomQueryCriteria( criteria );
-		jobContextData.setEntityTypes( entityTypesToIndex );
+		jobContextData.setEntityTypeDescriptors( descriptors );
 		return jobContextData;
 	}
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PartitionBound.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PartitionBound.java
@@ -23,13 +23,6 @@ public class PartitionBound {
 	private Object upperBound;
 	private IndexScope indexScope;
 
-	public PartitionBound() {
-	}
-
-	public PartitionBound(Class<?> entityType) {
-		this.entityType = entityType;
-	}
-
 	public PartitionBound(Class<?> entityType, Object lowerBound, Object upperBound, IndexScope indexScope) {
 		this.entityType = entityType;
 		this.lowerBound = lowerBound;
@@ -53,24 +46,20 @@ public class PartitionBound {
 		return lowerBound;
 	}
 
+	public void setLowerBound(Object lowerBound) {
+		this.lowerBound = lowerBound;
+	}
+
 	public Object getUpperBound() {
 		return upperBound;
 	}
 
-	public boolean isFirstPartition() {
-		return lowerBound == null && upperBound != null;
+	public boolean hasUpperBound() {
+		return upperBound != null;
 	}
 
-	public boolean isLastPartition() {
-		return lowerBound != null && upperBound == null;
-	}
-
-	public boolean isUniquePartition() {
-		return lowerBound == null && upperBound == null;
-	}
-
-	public void setEntityType(Class<?> entityType) {
-		this.entityType = entityType;
+	public boolean hasLowerBound() {
+		return lowerBound != null;
 	}
 
 	@Override

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PersistenceUtil.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PersistenceUtil.java
@@ -6,19 +6,11 @@
  */
 package org.hibernate.search.jsr352.massindexing.impl.util;
 
-import java.beans.IntrospectionException;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
-import javax.persistence.EmbeddedId;
 import javax.persistence.EntityManagerFactory;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
-import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.EmbeddableType;
 import javax.persistence.metamodel.EntityType;
 import javax.persistence.metamodel.Metamodel;
@@ -28,13 +20,11 @@ import javax.persistence.metamodel.Type;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
-import org.hibernate.criterion.Conjunction;
 import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Order;
-import org.hibernate.criterion.Restrictions;
-import org.hibernate.criterion.SimpleExpression;
+import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.jsr352.massindexing.impl.steps.lucene.IndexScope;
 import org.hibernate.search.util.StringHelper;
+import org.hibernate.search.util.impl.CollectionHelper;
 
 /**
  * Internal utility class for persistence usage.
@@ -42,128 +32,6 @@ import org.hibernate.search.util.StringHelper;
  * @author Mincong Huang
  */
 public final class PersistenceUtil {
-
-	/**
-	 * The type of identifier(s) of a given {@link EntityType}.
-	 */
-	private enum IdType {
-		/**
-		 * The given entity type contains only one {@link Id} annotation.
-		 */
-		SINGLE_ID,
-		/**
-		 * The given entity type contains an {@link EmbeddedId} annotation.
-		 */
-		EMBEDDED_ID,
-		/**
-		 * The given entity type contains an {@link IdClass} annotation.
-		 */
-		ID_CLASS,
-		/**
-		 * The given entity type does not match any other case available from this enum. This should never happen.
-		 */
-		UNKNOWN
-	}
-
-	/**
-	 * Internal ID processor for processing customized criterion.
-	 */
-	private enum IdProcessor {
-		GE {
-
-			@Override
-			public <X> Criterion processIds(SingularAttribute<X, ?>[] idAttributes, Object idObj, String prefix)
-					throws Exception {
-				Conjunction[] or = new Conjunction[idAttributes.length];
-				prefix = prefix != null ? prefix : "";
-
-				for ( int i = 0; i < or.length; i++ ) {
-					// Group expressions together in a single conjunction (A and B and C...).
-					SimpleExpression[] and = new SimpleExpression[i + 1];
-					int j = 0;
-					for ( ; j < and.length - 1; j++ ) {
-						// The first N-1 expressions have symbol `=`
-						String key = idAttributes[j].getName();
-						Object val = getProperty( idObj, key );
-						and[j] = Restrictions.eq( prefix + key, val );
-					}
-					// The last expression has symbol `>=`
-					String key = idAttributes[j].getName();
-					Object val = getProperty( idObj, key );
-					and[j] = Restrictions.ge( prefix + key, val );
-
-					or[i] = Restrictions.conjunction( and );
-				}
-				// Group the disjunction of multiple expressions (X or Y or Z...).
-				return Restrictions.or( or );
-			}
-
-			@Override
-			public <X> Criterion processId(SingularAttribute<X, ?> idAttribute, Object obj) {
-				return Restrictions.ge( idAttribute.getName(), obj );
-			}
-		},
-		LT {
-
-			@Override
-			public <X> Criterion processIds(SingularAttribute<X, ?>[] idAttributes, Object idObj, String prefix)
-					throws Exception {
-				Conjunction[] or = new Conjunction[idAttributes.length];
-				prefix = prefix != null ? prefix : "";
-
-				for ( int i = 0; i < or.length; i++ ) {
-					// Group expressions together in a single conjunction (A and B and C...).
-					SimpleExpression[] and = new SimpleExpression[i + 1];
-					int j = 0;
-					for ( ; j < and.length - 1; j++ ) {
-						// The first N-1 expressions have symbol `=`
-						String key = idAttributes[j].getName();
-						Object val = getProperty( idObj, key );
-						and[j] = Restrictions.eq( prefix + key, val );
-					}
-					// The last expression has symbol `<`
-					String key = idAttributes[j].getName();
-					Object val = getProperty( idObj, key );
-					and[j] = Restrictions.lt( prefix + key, val );
-
-					or[i] = Restrictions.conjunction( and );
-				}
-				// Group the disjunction of multiple expressions (X or Y or Z...).
-				return Restrictions.or( or );
-			}
-
-			@Override
-			public <X> Criterion processId(SingularAttribute<X, ?> idAttribute, Object obj) {
-				return Restrictions.lt( idAttribute.getName(), obj );
-			}
-		};
-
-		/**
-		 * Processes multiple ID attributes of the given ID object. This method should be used when target entity has
-		 * multiple ID attributes, e.g. an entity annotated {@link IdClass}, or an entity having {@link EmbeddedId}.
-		 *
-		 * @param idAttributes An ID attributes array, <b>sorted</b> by the name of attribute.
-		 * @param idObj The ID object to process, in which all the ID attributes should have a public getter method.
-		 * @param prefix The ID property prefix. Only used for entity having {@link EmbeddedId}. In other case, set it
-		 * to {@code null}.
-		 * @param <X> The type containing the represented attribute.
-		 * @return The customized criterion.
-		 * @throws Exception When any exception occurs.
-		 */
-		public abstract <X> Criterion processIds(SingularAttribute<X, ?>[] idAttributes, Object idObj, String prefix)
-				throws Exception;
-
-		/**
-		 * Processes a single ID attribute of the given ID object. This method should be used when target entity has a
-		 * single ID attribute.
-		 *
-		 * @param idAttribute The unique ID attribute of this entity.
-		 * @param idObj The ID object to process.
-		 * @param <X> The type containing the represented attribute.
-		 * @return The standard criterion.
-		 */
-		public abstract <X> Criterion processId(SingularAttribute<X, ?> idAttribute, Object idObj);
-	}
 
 	private PersistenceUtil() {
 		// Private constructor, do not use it.
@@ -231,124 +99,60 @@ public final class PersistenceUtil {
 		}
 	}
 
-	/**
-	 * Creates a list of {@link Order} based on the ID attribute(s) inside the given entity type.
-	 *
-	 * @param entityManagerFactory Entity manager factory.
-	 * @param entity The entity type.
-	 * @param <X> The type containing the represented attribute.
-	 * @return A list of {@link Order}, sorted by lexicographical order on the ID attributes' name.
-	 */
-	public static <X> List<Order> createIdOrders(EntityManagerFactory entityManagerFactory, Class<X> entity) {
-		EntityType<X> entityType = entityManagerFactory.getMetamodel().entity( entity );
-		List<SingularAttribute<?, ?>> attributeList;
-		List<Order> orders = new ArrayList<>();
-
-		switch ( getIdTypeOf( entityType ) ) {
-			case SINGLE_ID:
-				Class<?> idJavaType = entityType.getIdType().getJavaType();
-				SingularAttribute<?, ?> idAttribute = entityType.getId( idJavaType );
-				orders.add( Order.asc( idAttribute.getName() ) );
-				return orders;
-
-			case EMBEDDED_ID:
-				Class<?> embeddable = entityType.getIdType().getJavaType();
-				EmbeddableType<?> embeddableType = entityManagerFactory.getMetamodel().embeddable( embeddable );
-				String embeddableName = entityType.getId( embeddable ).getName();
-
-				attributeList = new ArrayList<>( embeddableType.getSingularAttributes() );
-				attributeList.sort( Comparator.comparing( Attribute::getName ) );
-				attributeList.forEach( attr -> {
-					String propertyName = embeddableName + "." + attr.getName();
-					orders.add( Order.asc( propertyName ) );
-				} );
-				return orders;
-
-			case ID_CLASS:
-				attributeList = new ArrayList<>( entityType.getIdClassAttributes() );
-				attributeList.sort( Comparator.comparing( Attribute::getName ) );
-				attributeList.forEach( attr -> orders.add( Order.asc( attr.getName() ) ) );
-				return orders;
-
-			default:
-				throw new IllegalStateException( "Cannot determine IdType: this should never happen." );
-		}
-	}
-
-	public static List<Criterion> createCriterionList(
-			EntityManagerFactory entityManagerFactory,
-			PartitionBound partitionBound) throws Exception {
-		Class<?> entity = partitionBound.getEntityType();
+	public static List<EntityTypeDescriptor> createDescriptors(EntityManagerFactory entityManagerFactory, Set<Class<?>> types) {
+		List<EntityTypeDescriptor> result = CollectionHelper.newArrayList( types.size() );
 		Metamodel metamodel = entityManagerFactory.getMetamodel();
-		List<Criterion> result = new ArrayList<>();
-
-		if ( partitionBound.hasUpperBound() ) {
-			Object upperBound = partitionBound.getUpperBound();
-			result.add( processCriterion( metamodel, entity, upperBound, IdProcessor.LT ) );
-		}
-		if ( partitionBound.hasLowerBound() ) {
-			Object lowerBound = partitionBound.getLowerBound();
-			result.add( processCriterion( metamodel, entity, lowerBound, IdProcessor.GE ) );
+		for ( Class<?> type : types ) {
+			result.add( createDescriptor( metamodel, type ) );
 		}
 		return result;
 	}
 
-	@SuppressWarnings("unchecked")
-	private static <X> Criterion processCriterion(
-			Metamodel metamodel,
-			Class<X> entity,
-			Object idObj,
-			IdProcessor processor) throws Exception {
-		EntityType<X> entityType = metamodel.entity( entity );
-		List<SingularAttribute<?, ?>> attributeList;
-
-		switch ( getIdTypeOf( entityType ) ) {
-			case SINGLE_ID:
-				Class<?> idJavaType = entityType.getIdType().getJavaType();
-				return processor.processId( entityType.getId( idJavaType ), idObj );
-
-			case EMBEDDED_ID:
-				Class<?> embeddable = entityType.getIdType().getJavaType();
-				EmbeddableType<?> embeddableType = metamodel.embeddable( embeddable );
-				String embeddableName = entityType.getId( embeddable ).getName();
-				String prefix = embeddableName + ".";
-
-				attributeList = new ArrayList<>( embeddableType.getSingularAttributes() );
-				attributeList.sort( Comparator.comparing( Attribute::getName ) );
-				return processor.processIds( attributeList.toArray( new SingularAttribute[0] ), idObj, prefix );
-
-			case ID_CLASS:
-				attributeList = new ArrayList<>( entityType.getIdClassAttributes() );
-				attributeList.sort( Comparator.comparing( Attribute::getName ) );
-				return processor.processIds( attributeList.toArray( new SingularAttribute[0] ), idObj, null );
-
-			default:
-				throw new IllegalStateException( "Cannot determine IdType: this should never happen." );
-		}
+	private static <T> EntityTypeDescriptor createDescriptor(Metamodel metamodel, Class<T> type) {
+		EntityType<T> entityType = metamodel.entity( type );
+		IdOrder idOrder = createIdOrder( metamodel, entityType );
+		return new EntityTypeDescriptor( type, idOrder );
 	}
 
-	private static Object getProperty(Object obj, String propertyName)
-			throws IntrospectionException, InvocationTargetException, IllegalAccessException {
-		return new PropertyDescriptor( propertyName, obj.getClass() ).getReadMethod().invoke( obj );
-	}
-
-	private static IdType getIdTypeOf(EntityType<?> entityType) {
-		if ( entityType.hasSingleIdAttribute() ) {
-			if ( entityType.getIdType().getPersistenceType() == Type.PersistenceType.EMBEDDABLE ) {
-				return IdType.EMBEDDED_ID;
+	private static IdOrder createIdOrder(Metamodel metamodel, EntityType<?> entityType) {
+		try {
+			if ( entityType.hasSingleIdAttribute() ) {
+				if ( entityType.getIdType().getPersistenceType() == Type.PersistenceType.EMBEDDABLE ) {
+					Class<?> embeddable = entityType.getIdType().getJavaType();
+					EmbeddableType<?> embeddableType = metamodel.embeddable( embeddable );
+					String embeddableName = entityType.getId( embeddable ).getName();
+					return new CompositeIdOrder( embeddableName + ".", embeddableType.getSingularAttributes() );
+				}
+				else {
+					Class<?> idJavaType = entityType.getIdType().getJavaType();
+					SingularAttribute<?, ?> idAttribute = entityType.getId( idJavaType );
+					return new SingularIdOrder( idAttribute );
+				}
 			}
 			else {
-				return IdType.SINGLE_ID;
+				return new CompositeIdOrder( "", entityType.getIdClassAttributes() );
 			}
 		}
-		try {
-			entityType.getIdClassAttributes();
-			return IdType.ID_CLASS;
-		}
 		catch (IllegalArgumentException e) {
-			// It should never happen.
-			return IdType.UNKNOWN;
+			throw new AssertionFailure( "Cannot determine the identifier type: this should never happen.", e );
 		}
+	}
+
+	public static List<Criterion> createCriterionList(
+			EntityTypeDescriptor typeDescriptor,
+			PartitionBound partitionBound) throws Exception {
+		IdOrder idOrder = typeDescriptor.getIdOrder();
+		List<Criterion> result = new ArrayList<>();
+
+		if ( partitionBound.hasUpperBound() ) {
+			Object upperBound = partitionBound.getUpperBound();
+			result.add( idOrder.idLesser( upperBound ) );
+		}
+		if ( partitionBound.hasLowerBound() ) {
+			Object lowerBound = partitionBound.getLowerBound();
+			result.add( idOrder.idGreaterOrEqual( lowerBound ) );
+		}
+		return result;
 	}
 
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PersistenceUtil.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PersistenceUtil.java
@@ -6,13 +6,33 @@
  */
 package org.hibernate.search.jsr352.massindexing.impl.util;
 
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
+
+import javax.persistence.EmbeddedId;
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.metamodel.Attribute;
+import javax.persistence.metamodel.EmbeddableType;
+import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.Metamodel;
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.Type;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
+import org.hibernate.criterion.Conjunction;
 import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
 import org.hibernate.search.jsr352.massindexing.impl.steps.lucene.IndexScope;
 import org.hibernate.search.util.StringHelper;
 
@@ -22,6 +42,128 @@ import org.hibernate.search.util.StringHelper;
  * @author Mincong Huang
  */
 public final class PersistenceUtil {
+
+	/**
+	 * The type of identifier(s) of a given {@link EntityType}.
+	 */
+	private enum IdType {
+		/**
+		 * The given entity type contains only one {@link Id} annotation.
+		 */
+		SINGLE_ID,
+		/**
+		 * The given entity type contains an {@link EmbeddedId} annotation.
+		 */
+		EMBEDDED_ID,
+		/**
+		 * The given entity type contains an {@link IdClass} annotation.
+		 */
+		ID_CLASS,
+		/**
+		 * The given entity type does not match any other case available from this enum. This should never happen.
+		 */
+		UNKNOWN
+	}
+
+	/**
+	 * Internal ID processor for processing customized criterion.
+	 */
+	private enum IdProcessor {
+		GE {
+
+			@Override
+			public <X> Criterion processIds(SingularAttribute<X, ?>[] idAttributes, Object idObj, String prefix)
+					throws Exception {
+				Conjunction[] or = new Conjunction[idAttributes.length];
+				prefix = prefix != null ? prefix : "";
+
+				for ( int i = 0; i < or.length; i++ ) {
+					// Group expressions together in a single conjunction (A and B and C...).
+					SimpleExpression[] and = new SimpleExpression[i + 1];
+					int j = 0;
+					for ( ; j < and.length - 1; j++ ) {
+						// The first N-1 expressions have symbol `=`
+						String key = idAttributes[j].getName();
+						Object val = getProperty( idObj, key );
+						and[j] = Restrictions.eq( prefix + key, val );
+					}
+					// The last expression has symbol `>=`
+					String key = idAttributes[j].getName();
+					Object val = getProperty( idObj, key );
+					and[j] = Restrictions.ge( prefix + key, val );
+
+					or[i] = Restrictions.conjunction( and );
+				}
+				// Group the disjunction of multiple expressions (X or Y or Z...).
+				return Restrictions.or( or );
+			}
+
+			@Override
+			public <X> Criterion processId(SingularAttribute<X, ?> idAttribute, Object obj) {
+				return Restrictions.ge( idAttribute.getName(), obj );
+			}
+		},
+		LT {
+
+			@Override
+			public <X> Criterion processIds(SingularAttribute<X, ?>[] idAttributes, Object idObj, String prefix)
+					throws Exception {
+				Conjunction[] or = new Conjunction[idAttributes.length];
+				prefix = prefix != null ? prefix : "";
+
+				for ( int i = 0; i < or.length; i++ ) {
+					// Group expressions together in a single conjunction (A and B and C...).
+					SimpleExpression[] and = new SimpleExpression[i + 1];
+					int j = 0;
+					for ( ; j < and.length - 1; j++ ) {
+						// The first N-1 expressions have symbol `=`
+						String key = idAttributes[j].getName();
+						Object val = getProperty( idObj, key );
+						and[j] = Restrictions.eq( prefix + key, val );
+					}
+					// The last expression has symbol `<`
+					String key = idAttributes[j].getName();
+					Object val = getProperty( idObj, key );
+					and[j] = Restrictions.lt( prefix + key, val );
+
+					or[i] = Restrictions.conjunction( and );
+				}
+				// Group the disjunction of multiple expressions (X or Y or Z...).
+				return Restrictions.or( or );
+			}
+
+			@Override
+			public <X> Criterion processId(SingularAttribute<X, ?> idAttribute, Object obj) {
+				return Restrictions.lt( idAttribute.getName(), obj );
+			}
+		};
+
+		/**
+		 * Processes multiple ID attributes of the given ID object. This method should be used when target entity has
+		 * multiple ID attributes, e.g. an entity annotated {@link IdClass}, or an entity having {@link EmbeddedId}.
+		 *
+		 * @param idAttributes An ID attributes array, <b>sorted</b> by the name of attribute.
+		 * @param idObj The ID object to process, in which all the ID attributes should have a public getter method.
+		 * @param prefix The ID property prefix. Only used for entity having {@link EmbeddedId}. In other case, set it
+		 * to {@code null}.
+		 * @param <X> The type containing the represented attribute.
+		 * @return The customized criterion.
+		 * @throws Exception When any exception occurs.
+		 */
+		public abstract <X> Criterion processIds(SingularAttribute<X, ?>[] idAttributes, Object idObj, String prefix)
+				throws Exception;
+
+		/**
+		 * Processes a single ID attribute of the given ID object. This method should be used when target entity has a
+		 * single ID attribute.
+		 *
+		 * @param idAttribute The unique ID attribute of this entity.
+		 * @param idObj The ID object to process.
+		 * @param <X> The type containing the represented attribute.
+		 * @return The standard criterion.
+		 */
+		public abstract <X> Criterion processId(SingularAttribute<X, ?> idAttribute, Object idObj);
+	}
 
 	private PersistenceUtil() {
 		// Private constructor, do not use it.
@@ -33,7 +175,6 @@ public final class PersistenceUtil {
 	 *
 	 * @param entityManagerFactory entity manager factory
 	 * @param tenantId tenant ID, can be {@literal null} or empty.
-	 *
 	 * @return a new session
 	 */
 	public static Session openSession(EntityManagerFactory entityManagerFactory, String tenantId) {
@@ -57,7 +198,6 @@ public final class PersistenceUtil {
 	 *
 	 * @param entityManagerFactory entity manager factory
 	 * @param tenantId tenant ID, can be {@literal null} or empty.
-	 *
 	 * @return a new stateless session
 	 */
 	public static StatelessSession openStatelessSession(EntityManagerFactory entityManagerFactory, String tenantId) {
@@ -88,6 +228,126 @@ public final class PersistenceUtil {
 		}
 		else {
 			return IndexScope.FULL_ENTITY;
+		}
+	}
+
+	/**
+	 * Creates a list of {@link Order} based on the ID attribute(s) inside the given entity type.
+	 *
+	 * @param entityManagerFactory Entity manager factory.
+	 * @param entity The entity type.
+	 * @param <X> The type containing the represented attribute.
+	 * @return A list of {@link Order}, sorted by lexicographical order on the ID attributes' name.
+	 */
+	public static <X> List<Order> createIdOrders(EntityManagerFactory entityManagerFactory, Class<X> entity) {
+		EntityType<X> entityType = entityManagerFactory.getMetamodel().entity( entity );
+		List<SingularAttribute<?, ?>> attributeList;
+		List<Order> orders = new ArrayList<>();
+
+		switch ( getIdTypeOf( entityType ) ) {
+			case SINGLE_ID:
+				Class<?> idJavaType = entityType.getIdType().getJavaType();
+				SingularAttribute<?, ?> idAttribute = entityType.getId( idJavaType );
+				orders.add( Order.asc( idAttribute.getName() ) );
+				return orders;
+
+			case EMBEDDED_ID:
+				Class<?> embeddable = entityType.getIdType().getJavaType();
+				EmbeddableType<?> embeddableType = entityManagerFactory.getMetamodel().embeddable( embeddable );
+				String embeddableName = entityType.getId( embeddable ).getName();
+
+				attributeList = new ArrayList<>( embeddableType.getSingularAttributes() );
+				attributeList.sort( Comparator.comparing( Attribute::getName ) );
+				attributeList.forEach( attr -> {
+					String propertyName = embeddableName + "." + attr.getName();
+					orders.add( Order.asc( propertyName ) );
+				} );
+				return orders;
+
+			case ID_CLASS:
+				attributeList = new ArrayList<>( entityType.getIdClassAttributes() );
+				attributeList.sort( Comparator.comparing( Attribute::getName ) );
+				attributeList.forEach( attr -> orders.add( Order.asc( attr.getName() ) ) );
+				return orders;
+
+			default:
+				throw new IllegalStateException( "Cannot determine IdType: this should never happen." );
+		}
+	}
+
+	public static List<Criterion> createCriterionList(
+			EntityManagerFactory entityManagerFactory,
+			PartitionBound partitionBound) throws Exception {
+		Class<?> entity = partitionBound.getEntityType();
+		Metamodel metamodel = entityManagerFactory.getMetamodel();
+		List<Criterion> result = new ArrayList<>();
+
+		if ( partitionBound.hasUpperBound() ) {
+			Object upperBound = partitionBound.getUpperBound();
+			result.add( processCriterion( metamodel, entity, upperBound, IdProcessor.LT ) );
+		}
+		if ( partitionBound.hasLowerBound() ) {
+			Object lowerBound = partitionBound.getLowerBound();
+			result.add( processCriterion( metamodel, entity, lowerBound, IdProcessor.GE ) );
+		}
+		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <X> Criterion processCriterion(
+			Metamodel metamodel,
+			Class<X> entity,
+			Object idObj,
+			IdProcessor processor) throws Exception {
+		EntityType<X> entityType = metamodel.entity( entity );
+		List<SingularAttribute<?, ?>> attributeList;
+
+		switch ( getIdTypeOf( entityType ) ) {
+			case SINGLE_ID:
+				Class<?> idJavaType = entityType.getIdType().getJavaType();
+				return processor.processId( entityType.getId( idJavaType ), idObj );
+
+			case EMBEDDED_ID:
+				Class<?> embeddable = entityType.getIdType().getJavaType();
+				EmbeddableType<?> embeddableType = metamodel.embeddable( embeddable );
+				String embeddableName = entityType.getId( embeddable ).getName();
+				String prefix = embeddableName + ".";
+
+				attributeList = new ArrayList<>( embeddableType.getSingularAttributes() );
+				attributeList.sort( Comparator.comparing( Attribute::getName ) );
+				return processor.processIds( attributeList.toArray( new SingularAttribute[0] ), idObj, prefix );
+
+			case ID_CLASS:
+				attributeList = new ArrayList<>( entityType.getIdClassAttributes() );
+				attributeList.sort( Comparator.comparing( Attribute::getName ) );
+				return processor.processIds( attributeList.toArray( new SingularAttribute[0] ), idObj, null );
+
+			default:
+				throw new IllegalStateException( "Cannot determine IdType: this should never happen." );
+		}
+	}
+
+	private static Object getProperty(Object obj, String propertyName)
+			throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+		return new PropertyDescriptor( propertyName, obj.getClass() ).getReadMethod().invoke( obj );
+	}
+
+	private static IdType getIdTypeOf(EntityType<?> entityType) {
+		if ( entityType.hasSingleIdAttribute() ) {
+			if ( entityType.getIdType().getPersistenceType() == Type.PersistenceType.EMBEDDABLE ) {
+				return IdType.EMBEDDED_ID;
+			}
+			else {
+				return IdType.SINGLE_ID;
+			}
+		}
+		try {
+			entityType.getIdClassAttributes();
+			return IdType.ID_CLASS;
+		}
+		catch (IllegalArgumentException e) {
+			// It should never happen.
+			return IdType.UNKNOWN;
 		}
 	}
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/SingularIdOrder.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/SingularIdOrder.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.jsr352.massindexing.impl.util;
 
-import javax.persistence.metamodel.SingularAttribute;
-
 import org.hibernate.Criteria;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Order;
@@ -23,26 +21,26 @@ import org.hibernate.criterion.Restrictions;
  */
 public class SingularIdOrder implements IdOrder {
 
-	private final String idAttributeName;
+	private final String idPropertyName;
 
-	public SingularIdOrder(SingularAttribute<?, ?> idAttribute) {
+	public SingularIdOrder(String idPropertyName) {
 		super();
-		this.idAttributeName = idAttribute.getName();
+		this.idPropertyName = idPropertyName;
 	}
 
 	@Override
 	public Criterion idGreaterOrEqual(Object idObj) {
-		return Restrictions.ge( idAttributeName, idObj );
+		return Restrictions.ge( idPropertyName, idObj );
 	}
 
 	@Override
 	public Criterion idLesser(Object idObj) {
-		return Restrictions.lt( idAttributeName, idObj );
+		return Restrictions.lt( idPropertyName, idObj );
 	}
 
 	@Override
 	public void addAscOrder(Criteria criteria) {
-		criteria.addOrder( Order.asc( idAttributeName ) );
+		criteria.addOrder( Order.asc( idPropertyName ) );
 	}
 
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/SingularIdOrder.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/SingularIdOrder.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.impl.util;
+
+import javax.persistence.metamodel.SingularAttribute;
+
+import org.hibernate.Criteria;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Restrictions;
+
+/**
+ * Order over a single ID attribute.
+ * <p>
+ * This class should be used when target entity has a single ID attribute.
+ *
+ * @author Mincong Huang
+ * @author Yoann Rodiere
+ */
+public class SingularIdOrder implements IdOrder {
+
+	private final String idAttributeName;
+
+	public SingularIdOrder(SingularAttribute<?, ?> idAttribute) {
+		super();
+		this.idAttributeName = idAttribute.getName();
+	}
+
+	@Override
+	public Criterion idGreaterOrEqual(Object idObj) {
+		return Restrictions.ge( idAttributeName, idObj );
+	}
+
+	@Override
+	public Criterion idLesser(Object idObj) {
+		return Restrictions.lt( idAttributeName, idObj );
+	}
+
+	@Override
+	public void addAscOrder(Criteria criteria) {
+		criteria.addOrder( Order.asc( idAttributeName ) );
+	}
+
+}

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdTest.java
@@ -97,6 +97,8 @@ public class MassIndexingJobWithCompositeIdTest {
 		Properties props = MassIndexingJob.parameters()
 				.forEntities( EntityWithIdClass.class )
 				.restrictedBy( Restrictions.gt( "month", 6 ) )
+				.rowsPerPartition( 40 ) // Ensure there're more than 1 partitions, so that WHERE clause is applied.
+				.checkpointInterval( 20 )
 				.build();
 		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
 
@@ -125,6 +127,8 @@ public class MassIndexingJobWithCompositeIdTest {
 		Properties props = MassIndexingJob.parameters()
 				.forEntities( EntityWithEmbeddedId.class )
 				.restrictedBy( Restrictions.gt( "embeddableDateId.month", 6 ) )
+				.rowsPerPartition( 40 ) // Ensure there're more than 1 partitions, so that WHERE clause is applied.
+				.checkpointInterval( 20 )
 				.build();
 		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
 

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdTest.java
@@ -83,8 +83,8 @@ public class MassIndexingJobWithCompositeIdTest {
 	public void canHandleIdClass_strategyFull() throws Exception {
 		Properties props = MassIndexingJob.parameters()
 				.forEntities( EntityWithIdClass.class )
-				.rowsPerPartition( 40 ) // Ensure there're more than 1 partitions, so that WHERE clause is applied.
-				.checkpointInterval( 20 )
+				.rowsPerPartition( 13 ) // Ensure there're more than 1 partition, so that a WHERE clause is applied.
+				.checkpointInterval( 4 )
 				.build();
 		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
 
@@ -97,8 +97,8 @@ public class MassIndexingJobWithCompositeIdTest {
 		Properties props = MassIndexingJob.parameters()
 				.forEntities( EntityWithIdClass.class )
 				.restrictedBy( Restrictions.gt( "month", 6 ) )
-				.rowsPerPartition( 40 ) // Ensure there're more than 1 partitions, so that WHERE clause is applied.
-				.checkpointInterval( 20 )
+				.rowsPerPartition( 13 ) // Ensure there're more than 1 partition, so that a WHERE clause is applied.
+				.checkpointInterval( 4 )
 				.build();
 		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
 
@@ -111,8 +111,8 @@ public class MassIndexingJobWithCompositeIdTest {
 	public void canHandleEmbeddedId_strategyFull() throws Exception {
 		Properties props = MassIndexingJob.parameters()
 				.forEntities( EntityWithEmbeddedId.class )
-				.rowsPerPartition( 40 ) // Ensure there're more than 1 partitions, so that WHERE clause is applied.
-				.checkpointInterval( 20 )
+				.rowsPerPartition( 13 ) // Ensure there're more than 1 partition, so that a WHERE clause is applied.
+				.checkpointInterval( 4 )
 				.build();
 
 		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
@@ -127,8 +127,8 @@ public class MassIndexingJobWithCompositeIdTest {
 		Properties props = MassIndexingJob.parameters()
 				.forEntities( EntityWithEmbeddedId.class )
 				.restrictedBy( Restrictions.gt( "embeddableDateId.month", 6 ) )
-				.rowsPerPartition( 40 ) // Ensure there're more than 1 partitions, so that WHERE clause is applied.
-				.checkpointInterval( 20 )
+				.rowsPerPartition( 13 ) // Ensure there're more than 1 partition, so that a WHERE clause is applied.
+				.checkpointInterval( 4 )
 				.build();
 		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
 

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdTest.java
@@ -1,0 +1,153 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.search.jsr352.test.util.JobTestUtil.findIndexedResults;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Properties;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.jpa.Search;
+import org.hibernate.search.jsr352.massindexing.test.entity.EntityWithEmbeddedId;
+import org.hibernate.search.jsr352.massindexing.test.entity.EntityWithIdClass;
+import org.hibernate.search.jsr352.massindexing.test.id.EmbeddableDateId;
+import org.hibernate.search.jsr352.test.util.JobTestUtil;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests that mass indexing job can handle entity having
+ * {@link javax.persistence.EmbeddedId} annotation, or
+ * {@link javax.persistence.IdClass} annotation.
+ *
+ * @author Mincong Huang
+ */
+@TestForIssue(jiraKey = "HSEARCH-2615")
+public class MassIndexingJobWithCompositeIdTest {
+
+	private static final LocalDate START = LocalDate.of( 2017, 6, 1 );
+
+	private static final LocalDate END = LocalDate.of( 2017, 8, 1 );
+
+	private static final EntityManagerFactory emf = Persistence.createEntityManagerFactory( "h2" );
+
+	private FullTextEntityManager ftem;
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		emf.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		ftem = Search.getFullTextEntityManager( emf.createEntityManager() );
+		ftem.getTransaction().begin();
+		for ( LocalDate d = START; d.isBefore( END ); d = d.plusDays( 1 ) ) {
+			ftem.persist( new EntityWithIdClass( d ) );
+			ftem.persist( new EntityWithEmbeddedId( d ) );
+		}
+		ftem.getTransaction().commit();
+
+		assertThat( JobTestUtil.nbDocumentsInIndex( emf, EntityWithIdClass.class ) ).isEqualTo( 0 );
+		assertThat( JobTestUtil.nbDocumentsInIndex( emf, EntityWithEmbeddedId.class ) ).isEqualTo( 0 );
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ftem.getTransaction().begin();
+
+		ftem.createQuery( "delete from " + EntityWithIdClass.class.getSimpleName() ).executeUpdate();
+		ftem.createQuery( "delete from " + EntityWithEmbeddedId.class.getSimpleName() ).executeUpdate();
+
+		ftem.purgeAll( EntityWithIdClass.class );
+		ftem.purgeAll( EntityWithEmbeddedId.class );
+		ftem.flushToIndexes();
+
+		ftem.getTransaction().commit();
+		ftem.close();
+	}
+
+	@Test
+	public void canHandleIdClass_strategyFull() throws Exception {
+		Properties props = MassIndexingJob.parameters()
+				.forEntities( EntityWithIdClass.class )
+				.rowsPerPartition( 40 ) // Ensure there're more than 1 partitions, so that WHERE clause is applied.
+				.checkpointInterval( 20 )
+				.build();
+		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
+
+		int expectedDays = (int) ChronoUnit.DAYS.between( START, END );
+		assertThat( JobTestUtil.nbDocumentsInIndex( emf, EntityWithIdClass.class ) ).isEqualTo( expectedDays );
+	}
+
+	@Test
+	public void canHandleIdClass_strategyCriteria() throws Exception {
+		Properties props = MassIndexingJob.parameters()
+				.forEntities( EntityWithIdClass.class )
+				.restrictedBy( Restrictions.gt( "month", 6 ) )
+				.build();
+		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
+
+		int expectedDays = (int) ChronoUnit.DAYS.between( LocalDate.of( 2017, 7, 1 ), END );
+		int actualDays = JobTestUtil.nbDocumentsInIndex( emf, EntityWithIdClass.class );
+		assertThat( actualDays ).isEqualTo( expectedDays );
+	}
+
+	@Test
+	public void canHandleEmbeddedId_strategyFull() throws Exception {
+		Properties props = MassIndexingJob.parameters()
+				.forEntities( EntityWithEmbeddedId.class )
+				.rowsPerPartition( 40 ) // Ensure there're more than 1 partitions, so that WHERE clause is applied.
+				.checkpointInterval( 20 )
+				.build();
+
+		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
+
+		int expectedDays = (int) ChronoUnit.DAYS.between( START, END );
+		int actualDays = JobTestUtil.nbDocumentsInIndex( emf, EntityWithEmbeddedId.class );
+		assertThat( actualDays ).isEqualTo( expectedDays );
+	}
+
+	/**
+	 * Tests that entity having {@link EmbeddedId} can NOT be handled properly
+	 * when adding a restriction on {@link EmbeddedId} field. This is the limit
+	 * of our customized solution: we use our own comparator—a lexicographical
+	 * order of attribute's name—for ID attributes sorting. We assume that this
+	 * order is always true during the entire indexing process, but it can't be
+	 * when user adds his own restriction on the ID field.
+	 */
+	@Test
+	public void cannotHandleEmbeddedId_restrictedById() throws Exception {
+		Properties props = MassIndexingJob.parameters()
+				.forEntities( EntityWithEmbeddedId.class )
+				.restrictedBy( Restrictions.ge(
+						"embeddableDateId",
+						new EmbeddableDateId( LocalDate.of( 2017, 6, 20 ) )
+				) )
+				.build();
+
+		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
+
+		assertThat( findIndexedResults( emf, EntityWithEmbeddedId.class, "value", "20170701" ) ).hasSize( 0 );
+		int missingDays = (int) ChronoUnit.DAYS.between( LocalDate.of( 2017, 7, 1 ), LocalDate.of( 2017, 7, 20 ) );
+		int expectedDays = (int) ChronoUnit.DAYS.between( LocalDate.of( 2017, 6, 20 ), END );
+		int actualDays = JobTestUtil.nbDocumentsInIndex( emf, EntityWithEmbeddedId.class );
+		assertThat( actualDays ).isEqualTo( expectedDays - missingDays );
+	}
+
+}

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReaderTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReaderTest.java
@@ -9,6 +9,7 @@ package org.hibernate.search.jsr352.massindexing.impl.steps.lucene;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.Arrays;
 import java.util.HashSet;
 
 import javax.batch.runtime.context.JobContext;
@@ -20,6 +21,7 @@ import javax.persistence.Persistence;
 import org.hibernate.search.jsr352.logging.impl.Log;
 import org.hibernate.search.jsr352.massindexing.impl.JobContextData;
 import org.hibernate.search.jsr352.massindexing.test.entity.Company;
+import org.hibernate.search.jsr352.test.util.JobTestUtil;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import org.junit.Before;
@@ -100,7 +102,7 @@ public class EntityReaderTest {
 		JobContextData jobData = new JobContextData();
 		jobData.setEntityManagerFactory( emf );
 		jobData.setCustomQueryCriteria( new HashSet<>() );
-		jobData.setEntityTypes( Company.class );
+		jobData.setEntityTypeDescriptors( Arrays.asList( JobTestUtil.createSimpleEntityTypeDescriptor( emf, Company.class ) ) );
 		Mockito.when( mockedJobContext.getTransientUserData() ).thenReturn( jobData );
 
 		// mock step context

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapperTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapperTest.java
@@ -8,6 +8,7 @@ package org.hibernate.search.jsr352.massindexing.impl.steps.lucene;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
 
@@ -21,6 +22,7 @@ import org.hibernate.search.jsr352.logging.impl.Log;
 import org.hibernate.search.jsr352.massindexing.impl.JobContextData;
 import org.hibernate.search.jsr352.massindexing.test.entity.Company;
 import org.hibernate.search.jsr352.massindexing.test.entity.Person;
+import org.hibernate.search.jsr352.test.util.JobTestUtil;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import org.junit.After;
@@ -103,7 +105,10 @@ public class PartitionMapperTest {
 		JobContextData jobData = new JobContextData();
 		jobData.setEntityManagerFactory( emf );
 		jobData.setCustomQueryCriteria( new HashSet<>() );
-		jobData.setEntityTypes( Company.class, Person.class );
+		jobData.setEntityTypeDescriptors( Arrays.asList(
+				JobTestUtil.createSimpleEntityTypeDescriptor( emf, Company.class ),
+				JobTestUtil.createSimpleEntityTypeDescriptor( emf, Person.class )
+				) );
 		Mockito.when( mockedJobContext.getTransientUserData() ).thenReturn( jobData );
 
 		PartitionPlan partitionPlan = partitionMapper.mapPartitions();

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/bridge/DateIdBridge.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/bridge/DateIdBridge.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.test.bridge;
+
+import java.util.Locale;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
+import org.hibernate.search.jsr352.massindexing.test.id.EmbeddableDateId;
+
+/**
+ * @author Mincong Huang
+ */
+public class DateIdBridge implements TwoWayFieldBridge {
+
+	@Override
+	public void set(String name, Object myDateIdObj, Document document, LuceneOptions luceneOptions) {
+		EmbeddableDateId myDateId = (EmbeddableDateId) myDateIdObj;
+
+		// cast int to string
+		String year = String.format( Locale.ROOT, "%04d", myDateId.getYear() );
+		String month = String.format( Locale.ROOT, "%02d", myDateId.getMonth() );
+		String day = String.format( Locale.ROOT, "%02d", myDateId.getDay() );
+
+		// store each property in a unique field
+		luceneOptions.addFieldToDocument( name + ".year", year, document );
+		luceneOptions.addFieldToDocument( name + ".month", month, document );
+		luceneOptions.addFieldToDocument( name + ".day", day, document );
+
+		// store the unique string representation in the named field
+		luceneOptions.addFieldToDocument( name, objectToString( myDateId ), document );
+	}
+
+	@Override
+	public Object get(String name, Document document) {
+		EmbeddableDateId myDateId = new EmbeddableDateId();
+		IndexableField idxField;
+
+		idxField = document.getField( name + ".year" );
+		myDateId.setYear( Integer.valueOf( idxField.stringValue() ) );
+
+		idxField = document.getField( name + ".month" );
+		myDateId.setMonth( Integer.valueOf( idxField.stringValue() ) );
+
+		idxField = document.getField( name + ".day" );
+		myDateId.setDay( Integer.valueOf( idxField.stringValue() ) );
+
+		return myDateId;
+	}
+
+	@Override
+	public String objectToString(Object myDateIdObj) {
+		return String.valueOf( myDateIdObj );
+	}
+
+}

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/entity/EntityWithEmbeddedId.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/entity/EntityWithEmbeddedId.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.test.entity;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.jsr352.massindexing.test.bridge.DateIdBridge;
+import org.hibernate.search.jsr352.massindexing.test.id.EmbeddableDateId;
+
+/**
+ * @author Mincong Huang
+ */
+@Entity
+@Indexed
+public class EntityWithEmbeddedId {
+
+	@EmbeddedId
+	@DocumentId
+	@FieldBridge(impl = DateIdBridge.class)
+	private EmbeddableDateId embeddableDateId;
+
+	@Field
+	private String value;
+
+	public EntityWithEmbeddedId() {
+	}
+
+	public EntityWithEmbeddedId(LocalDate d) {
+		this.embeddableDateId = new EmbeddableDateId( d );
+		this.value = DateTimeFormatter.ofPattern( "yyyyMMdd", Locale.ROOT ).format( d );
+	}
+
+	public EmbeddableDateId getEmbeddableDateId() {
+		return embeddableDateId;
+	}
+
+	public void setEmbeddableDateId(EmbeddableDateId embeddableDateId) {
+		this.embeddableDateId = embeddableDateId;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return "MyDate [embeddableDateId=" + embeddableDateId + ", value=" + value + "]";
+	}
+
+}

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/entity/EntityWithIdClass.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/entity/EntityWithIdClass.java
@@ -1,0 +1,85 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.test.entity;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.jsr352.massindexing.test.id.DatePK;
+
+/**
+ * Entity containing multiple {@link Id} attributes.
+ *
+ * @author Mincong Huang
+ */
+@Entity
+@Indexed
+@IdClass( DatePK.class )
+public class EntityWithIdClass implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private int year;
+
+	private int month;
+
+	private int day;
+
+	private int documentId;
+
+	public EntityWithIdClass() {
+	}
+
+	public EntityWithIdClass(LocalDate d) {
+		year = d.getYear();
+		month = d.getMonthValue();
+		day = d.getDayOfMonth();
+		documentId = year * 1_00_00 + month * 1_00 + day;
+	}
+
+	public void setYear(int year) {
+		this.year = year;
+	}
+
+	@Id
+	public int getYear() {
+		return year;
+	}
+
+	public void setMonth(int month) {
+		this.month = month;
+	}
+
+	@Id
+	public int getMonth() {
+		return month;
+	}
+
+	public void setDay(int day) {
+		this.day = day;
+	}
+
+	@Id
+	public int getDay() {
+		return day;
+	}
+
+	@DocumentId
+	public int getDocumentId() {
+		return documentId;
+	}
+
+	public void setDocumentId(int documentId) {
+		this.documentId = documentId;
+	}
+
+}

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/id/DatePK.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/id/DatePK.java
@@ -1,0 +1,96 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.test.id;
+
+import java.io.Serializable;
+import java.util.Locale;
+
+import org.hibernate.search.jsr352.massindexing.test.entity.EntityWithIdClass;
+
+/**
+ * Primary key for {@link EntityWithIdClass}.
+ *
+ * @author Mincong Huang
+ */
+public class DatePK implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private int year;
+
+	private int month;
+
+	private int day;
+
+	public DatePK() {
+
+	}
+
+	public void setYear(int year) {
+		this.year = year;
+	}
+
+	public int getYear() {
+		return year;
+	}
+
+	public void setMonth(int month) {
+		this.month = month;
+	}
+
+	public int getMonth() {
+		return month;
+	}
+
+	public void setDay(int day) {
+		this.day = day;
+	}
+
+	public int getDay() {
+		return day;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + day;
+		result = prime * result + month;
+		result = prime * result + year;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		DatePK that = (DatePK) obj;
+		if ( day != that.day ) {
+			return false;
+		}
+		if ( month != that.month ) {
+			return false;
+		}
+		if ( year != that.year ) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "%04d-%02d-%02d", year, month, day );
+	}
+
+}

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/id/EmbeddableDateId.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/id/EmbeddableDateId.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.test.id;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Locale;
+
+import javax.persistence.Embeddable;
+
+import org.hibernate.search.jsr352.massindexing.test.entity.EntityWithEmbeddedId;
+
+/**
+ * Primary key for {@link EntityWithEmbeddedId}.
+ *
+ * @author Mincong Huang
+ */
+@Embeddable
+public class EmbeddableDateId implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private int year;
+
+	private int month;
+
+	private int day;
+
+	public EmbeddableDateId() {
+
+	}
+
+	public EmbeddableDateId(LocalDate d) {
+		this.year = d.getYear();
+		this.month = d.getMonthValue();
+		this.day = d.getDayOfMonth();
+	}
+
+	public int getYear() {
+		return year;
+	}
+
+	public void setYear(int year) {
+		this.year = year;
+	}
+
+	public int getMonth() {
+		return month;
+	}
+
+	public void setMonth(int month) {
+		this.month = month;
+	}
+
+	public int getDay() {
+		return day;
+	}
+
+	public void setDay(int day) {
+		this.day = day;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + day;
+		result = prime * result + month;
+		result = prime * result + year;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		EmbeddableDateId that = (EmbeddableDateId) obj;
+		if ( day != that.day ) {
+			return false;
+		}
+		if ( month != that.month ) {
+			return false;
+		}
+		if ( year != that.year ) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "%04d-%02d-%02d", year, month, day );
+	}
+
+}

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
@@ -112,7 +112,7 @@ public final class JobTestUtil {
 	public static EntityTypeDescriptor createSimpleEntityTypeDescriptor(EntityManagerFactory emf, Class<?> clazz) {
 		EntityType<?> entityType = emf.getMetamodel().entity( clazz );
 		SingularAttribute<?, ?> idAttribute = entityType.getId( entityType.getIdType().getJavaType() );
-		return new EntityTypeDescriptor( clazz, new SingularIdOrder( idAttribute ) );
+		return new EntityTypeDescriptor( clazz, new SingularIdOrder( idAttribute.getName() ) );
 	}
 
 }

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
@@ -13,6 +13,8 @@ import javax.batch.runtime.BatchRuntime;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.SingularAttribute;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -21,6 +23,8 @@ import org.hibernate.search.Search;
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.FullTextQuery;
 import org.hibernate.search.jsr352.logging.impl.Log;
+import org.hibernate.search.jsr352.massindexing.impl.util.EntityTypeDescriptor;
+import org.hibernate.search.jsr352.massindexing.impl.util.SingularIdOrder;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -103,6 +107,12 @@ public final class JobTestUtil {
 		@SuppressWarnings("unchecked")
 		List<T> result = fts.createFullTextQuery( luceneQuery ).getResultList();
 		return result;
+	}
+
+	public static EntityTypeDescriptor createSimpleEntityTypeDescriptor(EntityManagerFactory emf, Class<?> clazz) {
+		EntityType<?> entityType = emf.getMetamodel().entity( clazz );
+		SingularAttribute<?, ?> idAttribute = entityType.getId( entityType.getIdType().getJavaType() );
+		return new EntityTypeDescriptor( clazz, new SingularIdOrder( idAttribute ) );
 	}
 
 }

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
@@ -7,7 +7,9 @@
 package org.hibernate.search.jsr352.test.util;
 
 import java.util.List;
+import java.util.Properties;
 import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchRuntime;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 import javax.persistence.EntityManagerFactory;
@@ -16,10 +18,15 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.jpa.FullTextQuery;
 import org.hibernate.search.jsr352.logging.impl.Log;
+import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import org.apache.lucene.search.Query;
+
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Yoann Rodiere
@@ -30,7 +37,17 @@ public final class JobTestUtil {
 
 	private static final int THREAD_SLEEP = 1000;
 
+	private static final int JOB_TIMEOUT_MS = 5_000;
+
 	private JobTestUtil() {
+	}
+
+	public static void startJobAndWait(String jobName, Properties jobParams) throws InterruptedException {
+		JobOperator jobOperator = BatchRuntime.getJobOperator();
+		long execId = jobOperator.start( jobName, jobParams );
+		JobExecution jobExec = jobOperator.getJobExecution( execId );
+		jobExec = JobTestUtil.waitForTermination( jobOperator, jobExec, JOB_TIMEOUT_MS );
+		assertThat( jobExec.getBatchStatus() ).isEqualTo( BatchStatus.COMPLETED );
 	}
 
 	public static JobExecution waitForTermination(JobOperator jobOperator, JobExecution jobExecution, int timeoutInMs)
@@ -53,6 +70,14 @@ public final class JobTestUtil {
 		}
 
 		return jobExecution;
+	}
+
+	public static <T> int nbDocumentsInIndex(EntityManagerFactory emf, Class<T> clazz) {
+		FullTextEntityManager em = org.hibernate.search.jpa.Search.getFullTextEntityManager( emf.createEntityManager() );
+		QueryBuilder queryBuilder = em.getSearchFactory().buildQueryBuilder().forEntity( clazz ).get();
+		Query allQuery = queryBuilder.all().createQuery();
+		FullTextQuery fullTextQuery = em.createFullTextQuery( allQuery, clazz );
+		return fullTextQuery.getResultSize();
 	}
 
 	public static <T> List<T> findIndexedResults(EntityManagerFactory emf, Class<T> clazz, String key, String value) {

--- a/jsr352/core/src/test/resources/META-INF/persistence.xml
+++ b/jsr352/core/src/test/resources/META-INF/persistence.xml
@@ -16,9 +16,9 @@
             <property name="hibernate.connection.driver_class" value="org.h2.Driver" />
             <property name="hibernate.connection.url" value="jdbc:h2:mem:company" />
             <property name="hibernate.connection.user" value="sa" />
-            <property name="hibernate.show_sql" value="false" />
+            <property name="hibernate.show_sql" value="true" />
             <property name="hibernate.flushMode" value="FLUSH_AUTO" />
-            <property name="hibernate.format_sql" value="false" />
+            <property name="hibernate.format_sql" value="true" />
             <property name="hibernate.hbm2ddl.auto" value="create-drop" />
             <property name="hibernate.search.default.directory_provider" value="ram" />
             <property name="hibernate.search.indexing_strategy" value="manual" />


### PR DESCRIPTION
Hi @yrodiere ,

Here's the PR for <https://hibernate.atlassian.net/browse/HSEARCH-2615>. I actually didn't finish the ticket, but I want to have your opinion about this ticket before going further. The origin of this issue is that for entity-types having an `@EmbbededId`, their order is not well handled. For example, given an `@Embeddable` id having 3 fields (year, month, day-of-month), when indexing entities >= (2017, 06, 20), then (2017, 07, 01) will not be indexed, because the the field day-of-month 01 < 20.

However, this is not always true. After adding 2 test-cases in `MassIndexingJobWithEmbeddedIdTest`, I found that:

- `Comparable` embedded ID are handled correctly
- Non `Comparable` embedded ID are not handled correctly

It means that we have 2 solutions:

1. Restrict `@Embeddable` ID to be comparable, and document it
2. Allow `@Embeddable` ID to be non-comparable, and discover "nested" properties in the ID, if any, and build a sort + criteria for partitions explicitly based on that metadata, as you mentioned in the last exchange.

Which approach do you prefer?
