### PR TITLE
HSEARCH-2613 JSR-352: Allow to select the entities to be re-indexed through a HQL/JPQL query

### DIFF
--- a/documentation/src/main/asciidoc/manual-index.asciidoc
+++ b/documentation/src/main/asciidoc/manual-index.asciidoc
@@ -480,12 +480,13 @@ can call this method multiple times to add multiple criteria: only entities matc
 will be indexed. However, mixing this approach with the HQL restriction is not allowed.
 See <<jsr-352-index-scope>> for more detail and limitations.
 
-|`customQueryLimit`
-|`customQueryLimit(int)`
+|`maxResultsPerEntity`
+|`maxResultsPerEntity(int)`
 |Optional
 |-
-|The limit of number of entities read in a custom query. This parameter is only used under
-custom query approaches (HQL and criteria). The value defined must be greater than 0.
+|The maximum number of results to load per entity type. This parameter let you define a threshold
+value to avoid loading too many entities accidentally. The value defined must be greater than 0.
+The parameter is not used by default. It is equivalent to keyword `LIMIT` in SQL.
 
 |`checkpointInterval`
 |`checkpointInterval(int)`

--- a/documentation/src/main/asciidoc/manual-index.asciidoc
+++ b/documentation/src/main/asciidoc/manual-index.asciidoc
@@ -469,7 +469,7 @@ entity reader class. Set it to true when reading a complex graph with relations.
 |-
 |Use HQL / JPQL to index entities of a target entity type. Your query should contain only one entity
 type. Mixing this approach with the criteria restriction is not allowed. Please notice that there's
-no query validation for your input.
+no query validation for your input. See <<jsr-352-index-scope>> for more detail and limitations.
 
 |`customQueryCriteria` (Not available, query builder only)
 |`restrictedBy(Criterion)`
@@ -478,6 +478,7 @@ no query validation for your input.
 |Add criterion to construct a customized selection of mass-indexing under the criteria approach. You
 can call this method multiple times to add multiple criteria: only entities matching every criterion
 will be indexed. However, mixing this approach with the HQL restriction is not allowed.
+See <<jsr-352-index-scope>> for more detail and limitations.
 
 |`customQueryLimit`
 |`customQueryLimit(int)`
@@ -521,7 +522,7 @@ request maximum.
 |See <<jsr-352-emf,Selecting the persistence unit (EntityManagerFactory)>> 
 |===
 
-==== Define entities to be indexed
+==== [[jsr-352-index-scope]] Define index scope for each entity
 
 The mass indexing job allows you to define your own entities to be indexed -- you can start a full
 indexation or a partial indexation through 3 different methods: selecting the desired entity types,
@@ -561,9 +562,9 @@ use-case is to index the new entities appeared since yesterday.
 
 Note that, as detailed below, some features may not be supported depending on the restrictions.
 
-.Comparaison of each method
+.Comparaison of each index scope
 |===
-| Method | Indexation | Parallel Indexing | Checkpoint
+| Index Scope | Indexation | Parallel Indexing | Checkpoint
 
 | Full Indexation
 | Full Indexation
@@ -580,6 +581,18 @@ Note that, as detailed below, some features may not be supported depending on th
 | Supported
 | Supported
 |===
+
+[NOTE]
+====
+When using the HQL approach, there isn't any query validation before the job's start.
+If the query is invalid, the job will start and fail.
+
+Also, parallel indexing and recovery from failure are disabled when using an HQL-defined scope,
+because our current parallelism and failure recovery implementations rely on selection order,
+which might not be provided by the HQL given by user.
+
+Because of those limitations, we suggest you use this approach only for indexing small numbers of entities.
+====
 
 ==== Parallel indexing
 

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
@@ -179,7 +179,6 @@ public class RestartIT {
 		JobExecution jobExec2 = jobOperator.getJobExecution( execId2 );
 		JobTestUtil.waitForTermination( jobOperator, jobExec2, JOB_TIMEOUT_MS );
 
-		// FIXME The job should finish correctly
 		assertEquals( BatchStatus.COMPLETED, jobExec2.getBatchStatus() );
 		assertEquals( 0, messageManager.findMessagesFor( SDF.parse( "31/08/2016" ) ).size() );
 		assertEquals( DB_DAY2_ROWS, messageManager.findMessagesFor( SDF.parse( "01/09/2016" ) ).size() );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
@@ -154,7 +154,7 @@ public class RestartIT {
 	}
 
 	@Test
-	public void testJob_usingHQL() throws InterruptedException, IOException, ParseException {
+	public void testJob_usingHQL() throws Exception {
 		assertEquals( 0, messageManager.findMessagesFor( SDF.parse( "31/08/2016" ) ).size() );
 		assertEquals( 0, messageManager.findMessagesFor( SDF.parse( "01/09/2016" ) ).size() );
 
@@ -165,15 +165,24 @@ public class RestartIT {
 				MassIndexingJob.NAME,
 				MassIndexingJob.parameters()
 						.forEntity( Message.class )
-						.restrictedBy( "select m from Message m where day( m.date ) = 31" )
+						.restrictedBy( "select m from Message m where day( m.date ) = 1" )
 						.build()
 				);
 		JobExecution jobExec1 = BatchRuntime.getJobOperator().getJobExecution( execId1 );
 		jobExec1 = JobTestUtil.waitForTermination( jobOperator, jobExec1, JOB_TIMEOUT_MS );
 		JobInterruptorUtil.disable();
 
-		assertEquals( BatchStatus.COMPLETED, jobExec1.getBatchStatus() );
-		assertEquals( DB_DAY1_ROWS, messageManager.findMessagesFor( SDF.parse( "31/08/2016" ) ).size() );
-		assertEquals( 0, messageManager.findMessagesFor( SDF.parse( "01/09/2016" ) ).size() );
+		assertEquals( BatchStatus.FAILED, jobExec1.getBatchStatus() );
+
+		// Restart the job.
+		long execId2 = jobOperator.restart( execId1, null );
+		JobExecution jobExec2 = jobOperator.getJobExecution( execId2 );
+		JobTestUtil.waitForTermination( jobOperator, jobExec2, JOB_TIMEOUT_MS );
+
+		// FIXME The job should finish correctly
+		assertEquals( BatchStatus.COMPLETED, jobExec2.getBatchStatus() );
+		assertEquals( 0, messageManager.findMessagesFor( SDF.parse( "31/08/2016" ) ).size() );
+		assertEquals( DB_DAY2_ROWS, messageManager.findMessagesFor( SDF.parse( "01/09/2016" ) ).size() );
 	}
+
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -9,6 +9,7 @@ package org.hibernate.search.jsr352.massindexing;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -107,7 +108,7 @@ public final class MassIndexingJob {
 		private Integer maxThreads;
 		private Set<Criterion> customQueryCriteria;
 		private String customQueryHql;
-		private Integer customQueryLimit;
+		private Integer maxResultsPerEntity;
 		private String tenantId;
 
 		private ParametersBuilder(Class<?> entityType, Class<?>... entityTypes) {
@@ -196,18 +197,26 @@ public final class MassIndexingJob {
 		}
 
 		/**
-		 * The maximum number of results will be returned from the HQL / criteria. It is equivalent to keyword
+		 * The maximum number of results to load per entity type. This parameter let you define a
+		 * threshold value to avoid loading too many entities accidentally. The value defined must
+		 * be greater than 0. The parameter is not used by default. It is equivalent to keyword
 		 * {@literal LIMIT} in SQL.
 		 *
-		 * @param customQueryLimit the custom query limit.
+		 * @param maxResultsPerEntity the maximum number of results returned per entity type.
 		 *
 		 * @return itself
 		 */
-		public ParametersBuilder customQueryLimit(int customQueryLimit) {
-			if ( customQueryLimit < 1 ) {
-				throw new IllegalArgumentException( "customQueryLimit must be at least 1" );
+		public ParametersBuilder maxResultsPerEntity(int maxResultsPerEntity) {
+			if ( maxResultsPerEntity < 1 ) {
+				String msg = String.format(
+						Locale.ROOT,
+						"The value of parameter '%s' must be at least 1 (value=%d).",
+						MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY,
+						maxResultsPerEntity
+				);
+				throw new IllegalArgumentException( msg );
 			}
-			this.customQueryLimit = customQueryLimit;
+			this.maxResultsPerEntity = maxResultsPerEntity;
 			return this;
 		}
 
@@ -360,7 +369,7 @@ public final class MassIndexingJob {
 			addIfNotNull( jobParams, MassIndexingJobParameters.FETCH_SIZE, fetchSize );
 			addIfNotNull( jobParams, MassIndexingJobParameters.CUSTOM_QUERY_HQL, customQueryHql );
 			addIfNotNull( jobParams, MassIndexingJobParameters.CHECKPOINT_INTERVAL, checkpointInterval );
-			addIfNotNull( jobParams, MassIndexingJobParameters.CUSTOM_QUERY_LIMIT, customQueryLimit );
+			addIfNotNull( jobParams, MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY, maxResultsPerEntity );
 			addIfNotNull( jobParams, MassIndexingJobParameters.MAX_THREADS, maxThreads );
 			addIfNotNull( jobParams, MassIndexingJobParameters.OPTIMIZE_AFTER_PURGE, optimizeAfterPurge );
 			addIfNotNull( jobParams, MassIndexingJobParameters.OPTIMIZE_ON_FINISH, optimizeOnFinish );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
@@ -24,6 +24,8 @@ public final class MassIndexingJobParameters {
 
 	public static final String MAX_THREADS = "maxThreads";
 
+	public static final String MAX_RESULTS_PER_ENTITY = "maxResultsPerEntity";
+
 	public static final String FETCH_SIZE = "fetchSize";
 
 	public static final String CACHEABLE = "cacheable";
@@ -41,8 +43,6 @@ public final class MassIndexingJobParameters {
 	public static final String CUSTOM_QUERY_HQL = "customQueryHQL";
 
 	public static final String CUSTOM_QUERY_CRITERIA = "customQueryCriteria";
-
-	public static final String CUSTOM_QUERY_LIMIT = "customQueryLimit";
 
 	public static final String TENANT_ID = "tenantId";
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/JobContextSetupListener.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/JobContextSetupListener.java
@@ -25,11 +25,11 @@ import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CHECKPOINT_INTERVAL;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_CRITERIA;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_HQL;
-import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_LIMIT;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_TYPES;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.FETCH_SIZE;
+import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.MAX_THREADS;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.OPTIMIZE_AFTER_PURGE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.OPTIMIZE_ON_FINISH;
@@ -72,6 +72,10 @@ public class JobContextSetupListener extends AbstractJobListener {
 	private String serializedMaxThreads;
 
 	@Inject
+	@BatchProperty(name = MAX_RESULTS_PER_ENTITY)
+	private String serializedMaxResultsPerEntity;
+
+	@Inject
 	@BatchProperty(name = FETCH_SIZE)
 	private String serializedFetchSize;
 
@@ -102,10 +106,6 @@ public class JobContextSetupListener extends AbstractJobListener {
 	@Inject
 	@BatchProperty(name = CUSTOM_QUERY_CRITERIA)
 	private String serializedCustomQueryCriteria;
-
-	@Inject
-	@BatchProperty(name = CUSTOM_QUERY_LIMIT)
-	private String serializedCustomQueryLimit;
 
 	@Inject
 	private EntityManagerFactoryRegistry emfRegistry;
@@ -164,12 +164,12 @@ public class JobContextSetupListener extends AbstractJobListener {
 		int fetchSize = SerializationUtil.parseIntegerParameter( FETCH_SIZE, serializedFetchSize );
 		ValidationUtil.validatePositive( FETCH_SIZE, fetchSize );
 
-		if ( StringHelper.isNotEmpty( serializedCustomQueryLimit ) ) {
-			int customQueryLimit = SerializationUtil.parseIntegerParameter(
-					CUSTOM_QUERY_LIMIT,
-					serializedCustomQueryLimit
+		if ( StringHelper.isNotEmpty( serializedMaxResultsPerEntity ) ) {
+			int maxResultsPerEntity = SerializationUtil.parseIntegerParameter(
+					MAX_RESULTS_PER_ENTITY,
+					serializedMaxResultsPerEntity
 			);
-			ValidationUtil.validatePositive( CUSTOM_QUERY_LIMIT, customQueryLimit );
+			ValidationUtil.validatePositive( MAX_RESULTS_PER_ENTITY, maxResultsPerEntity );
 		}
 
 		SerializationUtil.parseBooleanParameter( CACHEABLE, serializedCacheable );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
@@ -122,6 +122,10 @@ public class EntityReader extends AbstractItemReader {
 	@BatchProperty(name = MassIndexingPartitionProperties.UPPER_BOUND)
 	private String serializedUpperBound;
 
+	@Inject
+	@BatchProperty(name = MassIndexingPartitionProperties.INDEX_SCOPE)
+	private String indexScopeName;
+
 	private EntityManagerFactory emf;
 
 	private Serializable checkpointId;
@@ -143,7 +147,8 @@ public class EntityReader extends AbstractItemReader {
 			String serializedMaxResultsPerEntity,
 			String partitionIdStr,
 			String serializedLowerBound,
-			String serializedUpperBound) {
+			String serializedUpperBound,
+			String indexScopeName) {
 		this.serializedCacheable = serializedCacheable;
 		this.entityName = entityName;
 		this.serializedFetchSize = serializedFetchSize;
@@ -152,6 +157,7 @@ public class EntityReader extends AbstractItemReader {
 		this.serializedPartitionId = partitionIdStr;
 		this.serializedLowerBound = serializedLowerBound;
 		this.serializedUpperBound = serializedUpperBound;
+		this.indexScopeName = indexScopeName;
 	}
 
 	/**
@@ -266,7 +272,8 @@ public class EntityReader extends AbstractItemReader {
 		Class<?> entityType = jobContextData.getIndexedType( entityName );
 		Object lowerBound = SerializationUtil.deserialize( serializedLowerBound );
 		Object upperBound = SerializationUtil.deserialize( serializedUpperBound );
-		return new PartitionBound( entityType, lowerBound, upperBound );
+		IndexScope indexScope = IndexScope.valueOf( indexScopeName );
+		return new PartitionBound( entityType, lowerBound, upperBound, indexScope );
 	}
 
 	private ScrollableResults buildScrollUsingHQL(StatelessSession ss, String HQL) {

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
@@ -230,17 +230,18 @@ public class EntityReader extends AbstractItemReader {
 		sessionFactory = emf.unwrap( SessionFactory.class );
 
 		PartitionContextData partitionData;
-		switch ( PersistenceUtil.getIndexScope( customQueryHql, jobData.getCustomQueryCriteria() ) ) {
+		IndexScope indexScope = IndexScope.valueOf( indexScopeName );
+		switch ( indexScope ) {
 			case HQL:
 				scroll = buildScrollUsingHQL( ss, customQueryHql );
-				partitionData = new PartitionContextData( partitionId, entityName );
+				partitionData = new PartitionContextData( partitionId, entityName, indexScope );
 				break;
 
 			case CRITERIA:
 			case FULL_ENTITY:
 				scroll = buildScrollUsingCriteria( ss, bound, checkpointId, jobData );
 				if ( checkpointId == null ) {
-					partitionData = new PartitionContextData( partitionId, entityName );
+					partitionData = new PartitionContextData( partitionId, entityName, indexScope );
 				}
 				else {
 					partitionData = (PartitionContextData) stepContext.getPersistentUserData();

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
@@ -40,7 +40,7 @@ import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CACHEABLE;
-import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_LIMIT;
+import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.FETCH_SIZE;
 import static org.hibernate.search.jsr352.massindexing.impl.util.MassIndexingPartitionProperties.PARTITION_ID;
 
@@ -103,8 +103,8 @@ public class EntityReader extends AbstractItemReader {
 	private String customQueryHql;
 
 	@Inject
-	@BatchProperty(name = MassIndexingJobParameters.CUSTOM_QUERY_LIMIT)
-	private String serializedCustomQueryLimit;
+	@BatchProperty(name = MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY)
+	private String serializedMaxResultsPerEntity;
 
 	@Inject
 	@BatchProperty(name = MassIndexingJobParameters.TENANT_ID)
@@ -140,7 +140,7 @@ public class EntityReader extends AbstractItemReader {
 			String entityName,
 			String serializedFetchSize,
 			String hql,
-			String serializedCustomQueryLimit,
+			String serializedMaxResultsPerEntity,
 			String partitionIdStr,
 			String serializedLowerBound,
 			String serializedUpperBound) {
@@ -148,7 +148,7 @@ public class EntityReader extends AbstractItemReader {
 		this.entityName = entityName;
 		this.serializedFetchSize = serializedFetchSize;
 		this.customQueryHql = hql;
-		this.serializedCustomQueryLimit = serializedCustomQueryLimit;
+		this.serializedMaxResultsPerEntity = serializedMaxResultsPerEntity;
 		this.serializedPartitionId = partitionIdStr;
 		this.serializedLowerBound = serializedLowerBound;
 		this.serializedUpperBound = serializedUpperBound;
@@ -275,8 +275,8 @@ public class EntityReader extends AbstractItemReader {
 		boolean cacheable = SerializationUtil.parseBooleanParameter( CACHEABLE, serializedCacheable );
 		int fetchSize = SerializationUtil.parseIntegerParameter( FETCH_SIZE, serializedFetchSize );
 
-		if ( StringHelper.isNotEmpty( serializedCustomQueryLimit ) ) {
-			int maxResults = SerializationUtil.parseIntegerParameter( CUSTOM_QUERY_LIMIT, serializedCustomQueryLimit );
+		if ( StringHelper.isNotEmpty( serializedMaxResultsPerEntity ) ) {
+			int maxResults = SerializationUtil.parseIntegerParameter( MAX_RESULTS_PER_ENTITY, serializedMaxResultsPerEntity );
 			query.setMaxResults( maxResults );
 		}
 		return query.setReadOnly( true )
@@ -318,8 +318,8 @@ public class EntityReader extends AbstractItemReader {
 		// build criteria using job context data
 		jobData.getCustomQueryCriteria().forEach( c -> criteria.add( c ) );
 
-		if ( StringHelper.isNotEmpty( serializedCustomQueryLimit ) ) {
-			int maxResults = SerializationUtil.parseIntegerParameter( CUSTOM_QUERY_LIMIT, serializedCustomQueryLimit );
+		if ( StringHelper.isNotEmpty( serializedMaxResultsPerEntity ) ) {
+			int maxResults = SerializationUtil.parseIntegerParameter( MAX_RESULTS_PER_ENTITY, serializedMaxResultsPerEntity );
 			criteria.setMaxResults( maxResults );
 		}
 		return criteria.addOrder( Order.asc( idName ) )

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/IndexScope.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/IndexScope.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.massindexing.impl.steps.lucene;
+
+import org.hibernate.Criteria;
+
+/**
+ * The index scope of a given entity type.
+ *
+ * @author Mincong Huang
+ */
+public enum IndexScope {
+	/**
+	 * Index entities restricted by the HQL / JPQL given by user.
+	 */
+	HQL,
+	/**
+	 * Index entities restricted the {@link Criteria} given by user.
+	 */
+	CRITERIA,
+	/**
+	 * Index all the entities found.
+	 */
+	FULL_ENTITY
+}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/LuceneDocProducer.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/LuceneDocProducer.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
 import javax.naming.NamingException;
 import javax.persistence.EntityManagerFactory;
 
-import org.hibernate.search.backend.AddLuceneWork;
+import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.bridge.spi.ConversionContext;
 import org.hibernate.search.bridge.util.impl.ContextualExceptionBridgeHelper;
@@ -52,6 +52,10 @@ public class LuceneDocProducer implements ItemProcessor {
 	@BatchProperty(name = MassIndexingJobParameters.TENANT_ID)
 	private String tenantId;
 
+	@Inject
+	@BatchProperty(name = MassIndexingPartitionProperties.INDEX_SCOPE)
+	private String indexScopeName;
+
 	private EntityManagerFactory emf;
 
 	private ExtendedSearchIntegrator searchIntegrator;
@@ -59,6 +63,7 @@ public class LuceneDocProducer implements ItemProcessor {
 	private DocumentBuilderIndexedEntity docBuilder;
 	private boolean isSetup = false;
 	private IndexedTypeIdentifier entityTypeIdentifier;
+	private IndexScope indexScope;
 
 	@Override
 	public Object processItem(Object item) throws Exception {
@@ -67,8 +72,7 @@ public class LuceneDocProducer implements ItemProcessor {
 			setup();
 			isSetup = true;
 		}
-		AddLuceneWork addWork = buildAddLuceneWork( item );
-		return addWork;
+		return buildWork( item );
 	}
 
 	/**
@@ -85,23 +89,17 @@ public class LuceneDocProducer implements ItemProcessor {
 		entityIndexBinding = searchIntegrator.getIndexBindings().get( entityTypeIdentifier );
 		docBuilder = entityIndexBinding.getDocumentBuilder();
 		emf = jobContextData.getEntityManagerFactory();
+		indexScope = IndexScope.valueOf( indexScopeName );
 	}
 
-	/**
-	 * Build addLuceneWork using input entity. This method is inspired by the current mass indexer implementation.
-	 *
-	 * @param entity selected entity, obtained from JPA entity manager. It is used to build Lucene work.
-	 * @param entityType the class type of selected entity
-	 * @return an addLuceneWork
-	 */
-	private AddLuceneWork buildAddLuceneWork(Object entity) {
+	private LuceneWork buildWork(Object entity) {
 		ConversionContext conversionContext = new ContextualExceptionBridgeHelper();
 
 		Serializable id = (Serializable) emf.getPersistenceUnitUtil()
 				.getIdentifier( entity );
 		TwoWayFieldBridge idBridge = docBuilder.getIdBridge();
 		conversionContext.pushIdentifierProperty();
-		String idInString = null;
+		String idInString;
 		try {
 			idInString = conversionContext
 					.setConvertedTypeId( entityTypeIdentifier )
@@ -116,19 +114,35 @@ public class LuceneDocProducer implements ItemProcessor {
 		if ( StringHelper.isEmpty( tenantId ) ) {
 			tenantId = null;
 		}
-		return docBuilder.createAddWork(
-				tenantId,
-				entityTypeIdentifier,
-				entity,
-				id,
-				idInString,
-				/*
-				 * Use the default instance initializer (likely HibernateStatelessInitializer),
-				 * because we don't need the fancy features provided by HibernateSessionLoadingInitializer:
-				 * in our case, we never mix entities from different sessions, since
-				 * each partition uses its own session.
-				 */
-				null,
-				conversionContext );
+
+		/*
+		 * Use the default instance initializer (likely HibernateStatelessInitializer),
+		 * because we don't need the fancy features provided by HibernateSessionLoadingInitializer:
+		 * in our case, we never mix entities from different sessions, since
+		 * each partition uses its own session.
+		 */
+		switch ( indexScope ) {
+			case HQL:
+				return docBuilder.createUpdateWork(
+						tenantId,
+						entityTypeIdentifier,
+						entity,
+						id,
+						idInString,
+						null,
+						conversionContext );
+			case CRITERIA:
+			case FULL_ENTITY:
+				return docBuilder.createAddWork(
+						tenantId,
+						entityTypeIdentifier,
+						entity,
+						id,
+						idInString,
+						null,
+						conversionContext );
+			default:
+				throw new IllegalStateException( "Unknown IndexScope: " + indexScope );
+		}
 	}
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/LuceneDocWriter.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/LuceneDocWriter.java
@@ -15,8 +15,8 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.hibernate.search.backend.AddLuceneWork;
 import org.hibernate.search.backend.FlushLuceneWork;
+import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.StreamingOperationExecutor;
 import org.hibernate.search.backend.impl.StreamingOperationExecutorSelector;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -75,18 +75,19 @@ public class LuceneDocWriter extends AbstractItemWriter {
 	 * Execute {@code LuceneWork}
 	 *
 	 * @param items a list of items, where each item is a list of Lucene works.
-	 * @throw Exception is thrown for any errors.
+	 *
+	 * @throws Exception is thrown for any errors.
 	 */
 	@Override
 	public void writeItems(List<Object> items) throws Exception {
 		IndexShardingStrategy shardingStrategy = entityIndexBinding.getSelectionStrategy();
 
 		for ( Object item : items ) {
-			AddLuceneWork addWork = (AddLuceneWork) item;
-			StreamingOperationExecutor executor = addWork.acceptIndexWorkVisitor(
+			LuceneWork work = (LuceneWork) item;
+			StreamingOperationExecutor executor = work.acceptIndexWorkVisitor(
 					StreamingOperationExecutorSelector.INSTANCE, null );
 			executor.performStreamOperation(
-					addWork,
+					work,
 					shardingStrategy,
 					null, // monitor,
 					FORCE_ASYNC );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionContextData.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionContextData.java
@@ -20,8 +20,8 @@ public class PartitionContextData implements Serializable {
 
 	private PartitionProgress partitionProgress;
 
-	public PartitionContextData(int partitionId, String entityName) {
-		partitionProgress = new PartitionProgress( partitionId, entityName );
+	public PartitionContextData(int partitionId, String entityName, IndexScope indexScope) {
+		partitionProgress = new PartitionProgress( partitionId, entityName, indexScope );
 	}
 
 	public void documentAdded(int increment) {

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
@@ -65,10 +65,6 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 
 	private static final Log log = LoggerFactory.make( Log.class );
 
-	private enum Type {
-		HQL, CRITERIA, FULL_ENTITY
-	}
-
 	@Inject
 	private JobContext jobContext;
 
@@ -136,7 +132,7 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 			List<PartitionBound> partitionBounds = new ArrayList<>();
 			Class<?> entityType;
 
-			switch ( typeOfSelection( customQueryHql, jobData.getCustomQueryCriteria() ) ) {
+			switch ( PersistenceUtil.getIndexScope( customQueryHql, jobData.getCustomQueryCriteria() ) ) {
 				case HQL:
 					entityType = entityTypes.get( 0 );
 					partitionBounds.add( new PartitionBound( entityType, null, null ) );
@@ -203,18 +199,6 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 			catch (Exception e) {
 				log.unableToCloseSession( e );
 			}
-		}
-	}
-
-	private Type typeOfSelection(String hql, Set<Criterion> criterions) {
-		if ( hql != null && !hql.isEmpty() ) {
-			return Type.HQL;
-		}
-		else if ( criterions != null && criterions.size() > 0 ) {
-			return Type.CRITERIA;
-		}
-		else {
-			return Type.FULL_ENTITY;
 		}
 	}
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
@@ -38,6 +38,7 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.FETCH_SIZE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.MAX_THREADS;
+import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ROWS_PER_PARTITION;
 
 /**
@@ -82,6 +83,10 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 	@Inject
 	@BatchProperty(name = MassIndexingJobParameters.MAX_THREADS)
 	private String serializedMaxThreads;
+
+	@Inject
+	@BatchProperty(name = MAX_RESULTS_PER_ENTITY)
+	private String serializedMaxResultsPerEntity;
 
 	@Inject
 	@BatchProperty(name = MassIndexingJobParameters.ROWS_PER_PARTITION)
@@ -247,6 +252,10 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 		Criteria criteria = ss.createCriteria( clazz );
 		if ( criterions != null ) {
 			criterions.forEach( c -> criteria.add( c ) );
+		}
+		if ( StringHelper.isNotEmpty( serializedMaxResultsPerEntity ) ) {
+			int maxResults = SerializationUtil.parseIntegerParameter( MAX_RESULTS_PER_ENTITY, serializedMaxResultsPerEntity );
+			criteria.setMaxResults( maxResults );
 		}
 		int fetchSize = SerializationUtil.parseIntegerParameter( FETCH_SIZE, serializedFetchSize );
 		ScrollableResults scroll = criteria

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionProgress.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionProgress.java
@@ -17,11 +17,13 @@ public class PartitionProgress implements Serializable {
 	private String entityName;
 	private int partitionId;
 	private long workDone;
+	private IndexScope indexScope;
 
-	public PartitionProgress(int partitionId, String entityName) {
+	public PartitionProgress(int partitionId, String entityName, IndexScope indexScope) {
 		this.partitionId = partitionId;
 		this.entityName = entityName;
 		this.workDone = 0L;
+		this.indexScope = indexScope;
 	}
 
 	/**
@@ -57,9 +59,13 @@ public class PartitionProgress implements Serializable {
 		this.workDone = workDone;
 	}
 
+	public IndexScope getIndexScope() {
+		return indexScope;
+	}
+
 	@Override
 	public String toString() {
 		return "PartitionProgress [workDone=" + workDone + ", entityName=" + entityName
-				+ ", partitionId=" + partitionId + "]";
+				+ ", partitionId=" + partitionId + ", indexScope=" + indexScope + "]";
 	}
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/MassIndexingPartitionProperties.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/MassIndexingPartitionProperties.java
@@ -23,4 +23,6 @@ public final class MassIndexingPartitionProperties {
 	public static final String LOWER_BOUND = "lowerBound";
 
 	public static final String UPPER_BOUND = "upperBound";
+
+	public static final String INDEX_SCOPE = "indexScope";
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PartitionBound.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PartitionBound.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.jsr352.massindexing.impl.util;
 
+import org.hibernate.search.jsr352.massindexing.impl.steps.lucene.IndexScope;
+
 /**
  * Information about a target partition which can not be stored in the partition properties as String values. In
  * particular, the boundary properties help us to identify the lower boundary and upper boundary of a given partition,
@@ -19,6 +21,7 @@ public class PartitionBound {
 	private Class<?> entityType;
 	private Object lowerBound;
 	private Object upperBound;
+	private IndexScope indexScope;
 
 	public PartitionBound() {
 	}
@@ -27,10 +30,15 @@ public class PartitionBound {
 		this.entityType = entityType;
 	}
 
-	public PartitionBound(Class<?> entityType, Object lowerBound, Object upperBound) {
+	public PartitionBound(Class<?> entityType, Object lowerBound, Object upperBound, IndexScope indexScope) {
 		this.entityType = entityType;
 		this.lowerBound = lowerBound;
 		this.upperBound = upperBound;
+		this.indexScope = indexScope;
+	}
+
+	public IndexScope getIndexScope() {
+		return indexScope;
 	}
 
 	public Class<?> getEntityType() {
@@ -67,6 +75,7 @@ public class PartitionBound {
 
 	@Override
 	public String toString() {
-		return "PartitionBound [entityType=" + entityType + ", lowerBound=" + lowerBound + ", upperBound=" + upperBound + "]";
+		return "PartitionBound [entityType=" + entityType + ", lowerBound=" + lowerBound + ", upperBound=" + upperBound
+				+ ", indexScope=" + indexScope + "]";
 	}
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PersistenceUtil.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/PersistenceUtil.java
@@ -6,11 +6,14 @@
  */
 package org.hibernate.search.jsr352.massindexing.impl.util;
 
+import java.util.Set;
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.search.jsr352.massindexing.impl.steps.lucene.IndexScope;
 import org.hibernate.search.util.StringHelper;
 
 /**
@@ -69,6 +72,23 @@ public final class PersistenceUtil {
 					.openStatelessSession();
 		}
 		return statelessSession;
+	}
+
+	/**
+	 * Determines the index scope using the input parameters.
+	 *
+	 * @see IndexScope
+	 */
+	public static IndexScope getIndexScope(String hql, Set<Criterion> criterionSet) {
+		if ( StringHelper.isNotEmpty( hql ) ) {
+			return IndexScope.HQL;
+		}
+		else if ( criterionSet != null && criterionSet.size() > 0 ) {
+			return IndexScope.CRITERIA;
+		}
+		else {
+			return IndexScope.FULL_ENTITY;
+		}
 	}
 
 }

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -61,6 +61,7 @@
                     <property name="partitionId" value="#{partitionPlan['partitionId']}" />
                     <property name="lowerBound" value="#{partitionPlan['lowerBound']}" />
                     <property name="upperBound" value="#{partitionPlan['upperBound']}" />
+                    <property name="indexScope" value="#{partitionPlan['indexScope']}" />
                     <property name="tenantId" value="#{jobParameters['tenantId']}" />
                     <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
@@ -72,6 +73,7 @@
                 <properties>
                     <property name="entityName" value="#{partitionPlan['entityName']}" />
                     <property name="tenantId" value="#{jobParameters['tenantId']}" />
+                    <property name="indexScope" value="#{partitionPlan['indexScope']}" />
                 </properties>
             </processor>
             <writer ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.LuceneDocWriter">

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -16,6 +16,7 @@
                 <property name="entityTypes" value="#{jobParameters['entityTypes']}" />
 
                 <property name="maxThreads" value="#{jobParameters['maxThreads']}" />
+                <property name="maxResultsPerEntity" value="#{jobParameters['maxResultsPerEntity']}" />
                 <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
                 <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
                 <property name="optimizeOnFinish" value="#{jobParameters['optimizeOnFinish']}?:true;" />
@@ -25,7 +26,6 @@
                 <property name="rowsPerPartition" value="#{jobParameters['rowsPerPartition']}?:1000;" />
 
                 <property name="customQueryCriteria" value="#{jobParameters['customQueryCriteria']}" />
-                <property name="customQueryLimit" value="#{jobParameters['customQueryLimit']}" />
             </properties>
         </listener>
     </listeners>
@@ -65,7 +65,7 @@
                     <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
-                    <property name="customQueryLimit" value="#{jobParameters['customQueryLimit']}" />
+                    <property name="maxResultsPerEntity" value="#{jobParameters['maxResultsPerEntity']}" />
                 </properties>
             </reader>
             <processor ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.LuceneDocProducer">
@@ -88,6 +88,7 @@
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
                     <property name="maxThreads" value="#{jobParameters['maxThreads']}" />
+                    <property name="maxResultsPerEntity" value="#{jobParameters['maxResultsPerEntity']}" />
                     <property name="rowsPerPartition" value="#{jobParameters['rowsPerPartition']}?:1000;" />
                 </properties>
             </mapper>

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParametersBuilderTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParametersBuilderTest.java
@@ -38,7 +38,7 @@ public class MassIndexingJobParametersBuilderTest {
 	private static final boolean OPTIMIZE_ON_FINISH = true;
 	private static final boolean PURGE_ALL_ON_START = true;
 	private static final int FETCH_SIZE = 100000;
-	private static final int CUSTOM_QUERY_LIMIT = 1000000;
+	private static final int MAX_RESULTS_PER_ENTITY = 10_000;
 	private static final int MAX_THREADS = 2;
 	private static final int ROWS_PER_PARTITION = 500;
 
@@ -48,7 +48,7 @@ public class MassIndexingJobParametersBuilderTest {
 				.forEntities( String.class, Integer.class )
 				.entityManagerFactoryReference( SESSION_FACTORY_NAME )
 				.fetchSize( FETCH_SIZE )
-				.customQueryLimit( CUSTOM_QUERY_LIMIT )
+				.maxResultsPerEntity( MAX_RESULTS_PER_ENTITY )
 				.maxThreads( MAX_THREADS )
 				.optimizeAfterPurge( OPTIMIZE_AFTER_PURGE )
 				.optimizeOnFinish( OPTIMIZE_ON_FINISH )
@@ -59,7 +59,7 @@ public class MassIndexingJobParametersBuilderTest {
 
 		assertEquals( SESSION_FACTORY_NAME, props.getProperty( MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE ) );
 		assertEquals( FETCH_SIZE, Integer.parseInt( props.getProperty( MassIndexingJobParameters.FETCH_SIZE ) ) );
-		assertEquals( CUSTOM_QUERY_LIMIT, Integer.parseInt( props.getProperty( MassIndexingJobParameters.CUSTOM_QUERY_LIMIT ) ) );
+		assertEquals( MAX_RESULTS_PER_ENTITY, Integer.parseInt( props.getProperty( MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY ) ) );
 		assertEquals( OPTIMIZE_AFTER_PURGE, Boolean.parseBoolean( props.getProperty( MassIndexingJobParameters.OPTIMIZE_AFTER_PURGE ) ) );
 		assertEquals( OPTIMIZE_ON_FINISH, Boolean.parseBoolean( props.getProperty( MassIndexingJobParameters.OPTIMIZE_ON_FINISH ) ) );
 		assertEquals( ROWS_PER_PARTITION, Integer.parseInt( props.getProperty( MassIndexingJobParameters.ROWS_PER_PARTITION ) ) );

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReaderTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReaderTest.java
@@ -88,8 +88,8 @@ public class EntityReaderTest {
 				maxResults,
 				partitionId,
 				null,
-				null
-				);
+				null,
+				IndexScope.FULL_ENTITY.name() );
 
 		MockitoAnnotations.initMocks( this );
 	}


### PR DESCRIPTION
Hi @yrodiere,

Here's the PR for <https://hibernate.atlassian.net/browse/HSEARCH-2613>, which consists several points:

- Document the limitation of the current state
- Rename parameter `customQueryLimit` to `maxResultsPerEntity`, and ensure this parameter limits correctly the maximum number of objects to index for all the index scopes (FULL / CRITERIA / HQL). Notice that the parameter limits the max-number by entity type.
- Ensure the job restart is handled correctly under the HQL/JPQL approach, by using a `UpdateLuceneWork` instead of `AddLuceneWork`.
- Update accordingly the monitoring logic of index progress for HQL/JPQL