### PR TITLE
HSEARCH-2672 Rename: entityManagerFactory{Scope -> Namespace}

### DIFF
--- a/documentation/src/main/asciidoc/manual-index.asciidoc
+++ b/documentation/src/main/asciidoc/manual-index.asciidoc
@@ -514,8 +514,8 @@ request maximum.
 |-
 |The string that will identify the `EntityManagerFactory`.
 
-|`entityManagerFactoryScope`
-|`entityManagerFactoryScope(String)`
+|`entityManagerFactoryNamespace`
+|`entityManagerFactoryNamespace(String)`
 |-
 |-
 |See <<jsr-352-emf,Selecting the persistence unit (EntityManagerFactory)>> 
@@ -769,7 +769,7 @@ If you want to use multiple persistence units, you will have to add two paramete
 mass indexer:
 
 * `entityManagerFactoryReference`: this is the string that will identify the `EntityManagerFactory`.
-* `entityManagerFactoryScope`: this allows to select how you want to reference the
+* `entityManagerFactoryNamespace`: this allows to select how you want to reference the
   `EntityManagerFactory`. Possible values are:
 
 ** `persistence-unit-name` (the default): use the persistence unit name defined in

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/MultipleEntityManagerFactoriesNotRegisteredAsBeansIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/MultipleEntityManagerFactoriesNotRegisteredAsBeansIT.java
@@ -69,7 +69,7 @@ public class MultipleEntityManagerFactoriesNotRegisteredAsBeansIT {
 
 		/*
 		 * We expect failure, because we can only retrieve the default PU by default
-		 * (unless a non-default scope is used, but that requires user configuration).
+		 * (unless a non-default namespace is used, but that requires user configuration).
 		 */
 		assertEquals( BatchStatus.FAILED, jobExec1.getBatchStatus() );
 	}

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/context/jpa/EntityManagerFactoryRegistry.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/context/jpa/EntityManagerFactoryRegistry.java
@@ -31,12 +31,13 @@ public interface EntityManagerFactoryRegistry {
 	/**
 	 * Retrieve a factory using the given scope.
 	 *
-	 * @param scope The scope of the reference; accepted scopes are implementation-dependent. Must be non-null and non-empty.
-	 * For instance an implementation could accept the scope 'persistence-unit-name', meaning
+	 * @param namespace The namespace of the reference; accepted namespaces are implementation-dependent.
+	 * Must be non-null and non-empty.
+	 * For instance an implementation could accept the namespace 'persistence-unit-name', meaning
 	 * that the reference will be interpreted as a persistence unit name.
 	 * @param reference The reference allowing to identify the factory uniquely. Must be non-null and non-empty.
 	 * @return The {@link EntityManagerFactory} for the given reference string.
 	 */
-	EntityManagerFactory get(String scope, String reference);
+	EntityManagerFactory get(String namespace, String reference);
 
 }

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/context/jpa/impl/ActiveSessionFactoryRegistry.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/context/jpa/impl/ActiveSessionFactoryRegistry.java
@@ -40,8 +40,8 @@ public class ActiveSessionFactoryRegistry implements MutableSessionFactoryRegist
 
 	private static final MutableSessionFactoryRegistry INSTANCE = new ActiveSessionFactoryRegistry();
 
-	private static final String PERSISTENCE_UNIT_NAME_SCOPE_NAME = "persistence-unit-name";
-	private static final String SESSION_FACTORY_NAME_SCOPE_NAME = "session-factory-name";
+	private static final String PERSISTENCE_UNIT_NAME_NAMESPACE = "persistence-unit-name";
+	private static final String SESSION_FACTORY_NAME_NAMESPACE = "session-factory-name";
 
 	public static MutableSessionFactoryRegistry getInstance() {
 		return INSTANCE;
@@ -96,28 +96,28 @@ public class ActiveSessionFactoryRegistry implements MutableSessionFactoryRegist
 
 	@Override
 	public EntityManagerFactory get(String reference) {
-		return get( PERSISTENCE_UNIT_NAME_SCOPE_NAME, reference );
+		return get( PERSISTENCE_UNIT_NAME_NAMESPACE, reference );
 	}
 
 	@Override
-	public EntityManagerFactory get(String scopeName, String reference) {
+	public EntityManagerFactory get(String namespace, String reference) {
 		SessionFactory factory;
 
-		switch ( scopeName ) {
-			case PERSISTENCE_UNIT_NAME_SCOPE_NAME:
+		switch ( namespace ) {
+			case PERSISTENCE_UNIT_NAME_NAMESPACE:
 				factory = sessionFactoriesByPUName.get( reference );
 				if ( factory == null ) {
 					throw log.cannotFindEntityManagerFactoryByPUName( reference );
 				}
 				break;
-			case SESSION_FACTORY_NAME_SCOPE_NAME:
+			case SESSION_FACTORY_NAME_NAMESPACE:
 				factory = sessionFactoriesByName.get( reference );
 				if ( factory == null ) {
 					throw log.cannotFindEntityManagerFactoryByName( reference );
 				}
 				break;
 			default:
-				throw log.unknownEntityManagerFactoryScope( scopeName );
+				throw log.unknownEntityManagerFactoryNamespace( namespace );
 		}
 
 		return factory;

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/logging/impl/Log.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/logging/impl/Log.java
@@ -30,10 +30,10 @@ import org.jboss.logging.annotations.MessageLogger;
 public interface Log extends org.hibernate.search.util.logging.impl.Log {
 
 	@Message(id = JSR_352_MESSAGES_START_ID + 1,
-			value = "An '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE + "' parameter was defined,"
+			value = "An '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE + "' parameter was defined,"
 					+ " but the '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE + "' parameter is empty."
 					+ " Please also set the '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE + "' parameter"
-					+ " to select an entity manager factory, or do not set the '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE
+					+ " to select an entity manager factory, or do not set the '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE
 					+ "' parameter to try to use a default entity manager factory."
 	)
 	SearchException entityManagerFactoryReferenceIsEmpty();
@@ -45,8 +45,8 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	SearchException noAvailableEntityManagerFactoryInCDI(String reference);
 
 	@Message(id = JSR_352_MESSAGES_START_ID + 3,
-			value = "Unknown entity manager factory scope: '%1$s'. Please use a supported scope.")
-	SearchException unknownEntityManagerFactoryScope(String scopeName);
+			value = "Unknown entity manager factory namespace: '%1$s'. Please use a supported namespace.")
+	SearchException unknownEntityManagerFactoryNamespace(String namespace);
 
 	@Message(id = JSR_352_MESSAGES_START_ID + 4,
 			value = "Exception while retrieving the EntityManagerFactory using @PersistenceUnit."
@@ -89,7 +89,7 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 			value = "Multiple entity manager factories are currently active."
 					+ " Please provide the name of the selected persistence unit to the batch indexing job through"
 					+ " the '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE
-					+ "' parameter (you may also use the '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE
+					+ "' parameter (you may also use the '" + MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE
 					+ "' parameter for more referencing options)."
 	)
 	SearchException tooManyActiveEntityManagerFactories();

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -13,6 +13,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.persistence.EntityManagerFactory;
+
 import org.hibernate.Criteria;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.search.exception.SearchException;
@@ -93,7 +95,7 @@ public final class MassIndexingJob {
 	public static class ParametersBuilder {
 
 		private final Set<Class<?>> entityTypes;
-		private String entityManagerFactoryScope;
+		private String entityManagerFactoryNamespace;
 		private String entityManagerFactoryReference;
 		private Boolean cacheable;
 		private Boolean optimizeAfterPurge;
@@ -118,8 +120,22 @@ public final class MassIndexingJob {
 			customQueryCriteria = new HashSet<>();
 		}
 
-		public ParametersBuilder entityManagerFactoryScope(String scope) {
-			this.entityManagerFactoryScope = scope;
+		/**
+		 * The string that allows to select how you want to reference the {@link EntityManagerFactory}.
+		 * Possible values are:
+		 * <ul>
+		 * <li><tt>persistence-unit-name</tt> (the default): use the persistence unit name defined
+		 * in <tt>persistence.xml</tt>.
+		 * <li><tt>session-factory-name</tt>: use the session factory name defined in the Hibernate
+		 * configuration by the <tt>hibernate.session_factory_name</tt> configuration property.
+		 * </ul>
+		 *
+		 * @param namespace the name of namespace to use
+		 *
+		 * @return itself
+		 */
+		public ParametersBuilder entityManagerFactoryNamespace(String namespace) {
+			this.entityManagerFactoryNamespace = namespace;
 			return this;
 		}
 
@@ -338,7 +354,7 @@ public final class MassIndexingJob {
 
 			Properties jobParams = new Properties();
 
-			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE, entityManagerFactoryScope );
+			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE, entityManagerFactoryNamespace );
 			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE, entityManagerFactoryReference );
 			addIfNotNull( jobParams, MassIndexingJobParameters.CACHEABLE, cacheable );
 			addIfNotNull( jobParams, MassIndexingJobParameters.FETCH_SIZE, fetchSize );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
@@ -16,7 +16,7 @@ public final class MassIndexingJobParameters {
 		// Private constructor, do not use
 	}
 
-	public static final String ENTITY_MANAGER_FACTORY_SCOPE = "entityManagerFactoryScope";
+	public static final String ENTITY_MANAGER_FACTORY_NAMESPACE = "entityManagerFactoryNamespace";
 
 	public static final String ENTITY_MANAGER_FACTORY_REFERENCE = "entityManagerFactoryReference";
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/JobContextSetupListener.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/JobContextSetupListener.java
@@ -26,8 +26,8 @@ import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_CRITERIA;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_HQL;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_LIMIT;
+import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE;
-import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_TYPES;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.FETCH_SIZE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.MAX_THREADS;
@@ -56,8 +56,8 @@ public class JobContextSetupListener extends AbstractJobListener {
 	private JobContext jobContext;
 
 	@Inject
-	@BatchProperty(name = ENTITY_MANAGER_FACTORY_SCOPE)
-	private String entityManagerFactoryScope;
+	@BatchProperty(name = ENTITY_MANAGER_FACTORY_NAMESPACE)
+	private String entityManagerFactoryNamespace;
 
 	@Inject
 	@BatchProperty(name = ENTITY_MANAGER_FACTORY_REFERENCE)
@@ -114,7 +114,7 @@ public class JobContextSetupListener extends AbstractJobListener {
 	public void beforeJob() throws Exception {
 		validateParameters();
 		JobContextUtil.getOrCreateData( jobContext,
-				emfRegistry, entityManagerFactoryScope, entityManagerFactoryReference,
+				emfRegistry, entityManagerFactoryNamespace, entityManagerFactoryReference,
 				serializedEntityTypes, serializedCustomQueryCriteria );
 	}
 
@@ -133,7 +133,7 @@ public class JobContextSetupListener extends AbstractJobListener {
 	private void validateEntityTypes() {
 		ValidationUtil.validateEntityTypes(
 				emfRegistry,
-				entityManagerFactoryScope,
+				entityManagerFactoryNamespace,
 				entityManagerFactoryReference,
 				serializedEntityTypes
 		);

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
@@ -65,8 +65,8 @@ public class EntityReader extends AbstractItemReader {
 	private JobContext jobContext;
 
 	@Inject
-	@BatchProperty(name = MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_SCOPE)
-	private String entityManagerFactoryScope;
+	@BatchProperty(name = MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE)
+	private String entityManagerFactoryNamespace;
 
 	@Inject
 	@BatchProperty(name = MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE)
@@ -258,7 +258,7 @@ public class EntityReader extends AbstractItemReader {
 	 */
 	private JobContextData getJobContextData() throws ClassNotFoundException, IOException {
 		return JobContextUtil.getOrCreateData( jobContext,
-				emfRegistry, entityManagerFactoryScope, entityManagerFactoryReference,
+				emfRegistry, entityManagerFactoryNamespace, entityManagerFactoryReference,
 				serializedEntityTypes, serializedCustomQueryCriteria );
 	}
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/JobContextUtil.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/util/JobContextUtil.java
@@ -51,11 +51,11 @@ public final class JobContextUtil {
 
 	public static JobContextData getOrCreateData(JobContext jobContext,
 			EntityManagerFactoryRegistry emfRegistry,
-			String entityManagerFactoryScope, String entityManagerFactoryReference,
+			String entityManagerFactoryNamespace, String entityManagerFactoryReference,
 			String entityTypes, String serializedCustomQueryCriteria) throws ClassNotFoundException, IOException {
 		JobContextData data = (JobContextData) jobContext.getTransientUserData();
 		if ( data == null ) {
-			EntityManagerFactory emf = getEntityManagerFactory( emfRegistry, entityManagerFactoryScope, entityManagerFactoryReference );
+			EntityManagerFactory emf = getEntityManagerFactory( emfRegistry, entityManagerFactoryNamespace, entityManagerFactoryReference );
 			data = createData( emf, entityTypes, serializedCustomQueryCriteria );
 			jobContext.setTransientUserData( data );
 		}
@@ -72,11 +72,11 @@ public final class JobContextUtil {
 	}
 
 	static EntityManagerFactory getEntityManagerFactory(EntityManagerFactoryRegistry emfRegistry,
-			String entityManagerFactoryScope, String entityManagerFactoryReference) {
+			String entityManagerFactoryNamespace, String entityManagerFactoryReference) {
 		EntityManagerFactoryRegistry registry =
 				emfRegistry != null ? emfRegistry : ActiveSessionFactoryRegistry.getInstance();
 
-		if ( StringHelper.isEmpty( entityManagerFactoryScope ) ) {
+		if ( StringHelper.isEmpty( entityManagerFactoryNamespace ) ) {
 			if ( StringHelper.isEmpty( entityManagerFactoryReference ) ) {
 				return registry.getDefault();
 			}
@@ -89,7 +89,7 @@ public final class JobContextUtil {
 				throw log.entityManagerFactoryReferenceIsEmpty();
 			}
 			else {
-				return registry.get( entityManagerFactoryScope, entityManagerFactoryReference );
+				return registry.get( entityManagerFactoryNamespace, entityManagerFactoryReference );
 			}
 		}
 	}

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -11,7 +11,7 @@
     <listeners>
         <listener ref="org.hibernate.search.jsr352.massindexing.impl.JobContextSetupListener">
             <properties>
-                <property name="entityManagerFactoryScope" value="#{jobParameters['entityManagerFactoryScope']}" />
+                <property name="entityManagerFactoryNamespace" value="#{jobParameters['entityManagerFactoryNamespace']}" />
                 <property name="entityManagerFactoryReference" value="#{jobParameters['entityManagerFactoryReference']}" />
                 <property name="entityTypes" value="#{jobParameters['entityTypes']}" />
 
@@ -52,7 +52,7 @@
             <reader ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.EntityReader">
                 <properties>
                 	<!-- Used to re-create the job context data as necessary -->
-	                <property name="entityManagerFactoryScope" value="#{jobParameters['entityManagerFactoryScope']}" />
+	                <property name="entityManagerFactoryNamespace" value="#{jobParameters['entityManagerFactoryNamespace']}" />
 	                <property name="entityManagerFactoryReference" value="#{jobParameters['entityManagerFactoryReference']}" />
 	                <property name="entityTypes" value="#{jobParameters['entityTypes']}" />
 	                <property name="customQueryCriteria" value="#{jobParameters['customQueryCriteria']}" />

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/BatchIndexingJobIT.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/BatchIndexingJobIT.java
@@ -140,8 +140,7 @@ public class BatchIndexingJobIT {
 	}
 
 	@Test
-	public void entityManagerFactoryScope_persistenceUnitName() throws InterruptedException,
-			IOException {
+	public void entityManagerFactoryNamespace_persistenceUnitName() throws Exception {
 		EntityManager em = emf.createEntityManager();
 		FullTextEntityManager ftem = Search.getFullTextEntityManager( em );
 		ftem.purgeAll( Company.class );
@@ -152,7 +151,7 @@ public class BatchIndexingJobIT {
 				MassIndexingJob.NAME,
 				MassIndexingJob.parameters()
 						.forEntity( Company.class )
-						.entityManagerFactoryScope( "persistence-unit-name" )
+						.entityManagerFactoryNamespace( "persistence-unit-name" )
 						.entityManagerFactoryReference( PERSISTENCE_UNIT_NAME )
 						.build()
 				);
@@ -164,8 +163,7 @@ public class BatchIndexingJobIT {
 	}
 
 	@Test
-	public void entityManagerFactoryScope_sessionFactoryName() throws InterruptedException,
-			IOException {
+	public void entityManagerFactoryNamespace_sessionFactoryName() throws Exception {
 		EntityManager em = emf.createEntityManager();
 		FullTextEntityManager ftem = Search.getFullTextEntityManager( em );
 		ftem.purgeAll( Company.class );
@@ -176,7 +174,7 @@ public class BatchIndexingJobIT {
 				MassIndexingJob.NAME,
 				MassIndexingJob.parameters()
 						.forEntity( Company.class )
-						.entityManagerFactoryScope( "session-factory-name" )
+						.entityManagerFactoryNamespace( "session-factory-name" )
 						.entityManagerFactoryReference( SESSION_FACTORY_NAME )
 						.build()
 				);

--- a/jsr352/jberet/src/main/java/org/hibernate/search/jsr352/jberet/context/jpa/impl/CDIEntityManagerFactoryRegistry.java
+++ b/jsr352/jberet/src/main/java/org/hibernate/search/jsr352/jberet/context/jpa/impl/CDIEntityManagerFactoryRegistry.java
@@ -86,7 +86,7 @@ public class CDIEntityManagerFactoryRegistry implements EntityManagerFactoryRegi
 
 	private static final Log log = LoggerFactory.make( Log.class );
 
-	private static final String CDI_SCOPE_NAME = "cdi";
+	private static final String CDI_NAMESPACE_NAME = "cdi";
 
 	@Inject
 	private Instance<EntityManagerFactory> entityManagerFactoryInstance;
@@ -114,15 +114,15 @@ public class CDIEntityManagerFactoryRegistry implements EntityManagerFactoryRegi
 
 	@Override
 	public EntityManagerFactory get(String reference) {
-		return get( CDI_SCOPE_NAME, reference );
+		return get( CDI_NAMESPACE_NAME, reference );
 	}
 
 	@Override
-	public EntityManagerFactory get(String scopeName, String reference) {
+	public EntityManagerFactory get(String namespace, String reference) {
 		EntityManagerFactory factory;
 
-		switch ( scopeName ) {
-			case CDI_SCOPE_NAME:
+		switch ( namespace ) {
+			case CDI_NAMESPACE_NAME:
 				Instance<EntityManagerFactory> instance = entityManagerFactoryInstance.select( new NamedQualifier( reference ) );
 				if ( instance.isUnsatisfied() ) {
 					throw log.noAvailableEntityManagerFactoryInCDI( reference );
@@ -130,7 +130,7 @@ public class CDIEntityManagerFactoryRegistry implements EntityManagerFactoryRegi
 				factory = instance.get();
 				break;
 			default:
-				throw log.unknownEntityManagerFactoryScope( scopeName );
+				throw log.unknownEntityManagerFactoryNamespace( namespace );
 		}
 
 		return factory;


### PR DESCRIPTION
Hi @yrodiere , here's the PR for ticket <https://hibernate.atlassian.net/browse/HSEARCH-2672>.

Renaming the job parameter from `entityManagerFactoryScope` to `entityManagerFactoryNamespace` because "scope" has a different meaning for CDI in particular, so it's a bit confusing.

