### PR TITLE
HSEARCH-2786 JSR-352: Split job parameter fetchSize into 2 parameters

### DIFF
--- a/documentation/src/main/asciidoc/manual-index.asciidoc
+++ b/documentation/src/main/asciidoc/manual-index.asciidoc
@@ -457,11 +457,21 @@ place after indexing.
 |Specify whether the Hibernate queries are cacheable. This setting will be applied to the internal
 entity reader class. Set it to true when reading a complex graph with relations.
 
-|`fetchSize`
-|`fetchSize(int)`
+|`idFetchSize`
+|`idFetchSize(int)`
 |Optional
-|100
-|The number of rows to retrieve for each database query.
+|1000
+|Specifies the fetch size to be used when loading primary keys. Some databases
+accept special values, for example MySQL might benefit from using `Integer#MIN_VALUE`, otherwise it
+will attempt to preload everything in memory.
+
+|`entityFetchSize`
+|`entityFetchSize(int)`
+|Optional
+|The value of `checkpointInterval`
+|Specifies the fetch size to be used when loading entities from database. Some databases
+accept special values, for example MySQL might benefit from using `Integer#MIN_VALUE`, otherwise it
+will attempt to preload everything in memory.
 
 |`customQueryHQL`
 |`restrictedBy(String)`

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -100,7 +100,8 @@ public final class MassIndexingJob {
 		private Boolean optimizeAfterPurge;
 		private Boolean optimizeOnFinish;
 		private Boolean purgeAllOnStart;
-		private Integer fetchSize;
+		private Integer idFetchSize;
+		private Integer entityFetchSize;
 		private Integer checkpointInterval;
 		private Integer rowsPerPartition;
 		private Integer maxThreads;
@@ -179,18 +180,37 @@ public final class MassIndexingJob {
 		}
 
 		/**
-		 * The number of rows to retrieve for each database query. This is an optional method, its default value is
-		 * {@literal 200,000}.
+		 * Specifies the fetch size to be used when loading primary keys at the
+		 * step-level. Some databases accept special values, for example MySQL
+		 * might benefit from using {@link Integer#MIN_VALUE}, otherwise it
+		 * will attempt to preload everything in memory.
+		 * <p>
+		 * This is an optional parameter.
 		 *
-		 * @param fetchSize the number of rows to retrieve for each database query.
+		 * @param idFetchSize the fetch size to be used when loading primary keys
 		 *
 		 * @return itself
 		 */
-		public ParametersBuilder fetchSize(int fetchSize) {
-			if ( fetchSize < 1 ) {
-				throw new IllegalArgumentException( "fetchSize must be at least 1" );
-			}
-			this.fetchSize = fetchSize;
+		public ParametersBuilder idFetchSize(int idFetchSize) {
+			this.idFetchSize = idFetchSize;
+			return this;
+		}
+
+		/**
+		 * Specifies the fetch size to be used when loading entities from
+		 * database. Some databases accept special values, for example MySQL
+		 * might benefit from using {@link Integer#MIN_VALUE}, otherwise it
+		 * will attempt to preload everything in memory.
+		 * <p>
+		 * This is an optional parameter. The default value is the value of
+		 * checkpoint interval.
+		 *
+		 * @param entityFetchSize the fetch size to be used when loading entities
+		 *
+		 * @return itself
+		 */
+		public ParametersBuilder entityFetchSize(int entityFetchSize) {
+			this.entityFetchSize = entityFetchSize;
 			return this;
 		}
 
@@ -364,7 +384,8 @@ public final class MassIndexingJob {
 			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE, entityManagerFactoryNamespace );
 			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE, entityManagerFactoryReference );
 			addIfNotNull( jobParams, MassIndexingJobParameters.CACHEABLE, cacheable );
-			addIfNotNull( jobParams, MassIndexingJobParameters.FETCH_SIZE, fetchSize );
+			addIfNotNull( jobParams, MassIndexingJobParameters.ID_FETCH_SIZE, idFetchSize );
+			addIfNotNull( jobParams, MassIndexingJobParameters.ENTITY_FETCH_SIZE, entityFetchSize );
 			addIfNotNull( jobParams, MassIndexingJobParameters.CUSTOM_QUERY_HQL, customQueryHql );
 			addIfNotNull( jobParams, MassIndexingJobParameters.CHECKPOINT_INTERVAL, checkpointInterval );
 			addIfNotNull( jobParams, MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY, maxResultsPerEntity );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParameters.java
@@ -26,7 +26,9 @@ public final class MassIndexingJobParameters {
 
 	public static final String MAX_RESULTS_PER_ENTITY = "maxResultsPerEntity";
 
-	public static final String FETCH_SIZE = "fetchSize";
+	public static final String ID_FETCH_SIZE = "idFetchSize";
+
+	public static final String ENTITY_FETCH_SIZE = "entityFetchSize";
 
 	public static final String CACHEABLE = "cacheable";
 

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/JobContextSetupListener.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/JobContextSetupListener.java
@@ -25,11 +25,12 @@ import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CHECKPOINT_INTERVAL;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_CRITERIA;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.CUSTOM_QUERY_HQL;
+import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_FETCH_SIZE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_NAMESPACE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ENTITY_TYPES;
-import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.FETCH_SIZE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY;
+import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.ID_FETCH_SIZE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.MAX_THREADS;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.OPTIMIZE_AFTER_PURGE;
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.OPTIMIZE_ON_FINISH;
@@ -76,8 +77,12 @@ public class JobContextSetupListener extends AbstractJobListener {
 	private String serializedMaxResultsPerEntity;
 
 	@Inject
-	@BatchProperty(name = FETCH_SIZE)
-	private String serializedFetchSize;
+	@BatchProperty(name = ID_FETCH_SIZE)
+	private String serializedIdFetchSize;
+
+	@Inject
+	@BatchProperty(name = ENTITY_FETCH_SIZE)
+	private String serializedEntityFetchSize;
 
 	@Inject
 	@BatchProperty(name = CACHEABLE)
@@ -161,8 +166,11 @@ public class JobContextSetupListener extends AbstractJobListener {
 	}
 
 	private void validateQuerying() {
-		int fetchSize = SerializationUtil.parseIntegerParameter( FETCH_SIZE, serializedFetchSize );
-		ValidationUtil.validatePositive( FETCH_SIZE, fetchSize );
+		SerializationUtil.parseIntegerParameter( ID_FETCH_SIZE, serializedIdFetchSize );
+
+		if ( StringHelper.isNotEmpty( serializedEntityFetchSize ) ) {
+			SerializationUtil.parseIntegerParameter( ENTITY_FETCH_SIZE, serializedEntityFetchSize );
+		}
 
 		if ( StringHelper.isNotEmpty( serializedMaxResultsPerEntity ) ) {
 			int maxResultsPerEntity = SerializationUtil.parseIntegerParameter(

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -17,7 +17,8 @@
 
                 <property name="maxThreads" value="#{jobParameters['maxThreads']}" />
                 <property name="maxResultsPerEntity" value="#{jobParameters['maxResultsPerEntity']}" />
-                <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
+                <property name="idFetchSize" value="#{jobParameters['idFetchSize']}?:1000;" />
+                <property name="entityFetchSize" value="#{jobParameters['entityFetchSize']}" />
                 <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
                 <property name="optimizeOnFinish" value="#{jobParameters['optimizeOnFinish']}?:true;" />
                 <property name="optimizeAfterPurge" value="#{jobParameters['optimizeAfterPurge']}?:true;" />
@@ -64,7 +65,8 @@
                     <property name="indexScope" value="#{partitionPlan['indexScope']}" />
                     <property name="tenantId" value="#{jobParameters['tenantId']}" />
                     <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
-                    <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
+                    <property name="entityFetchSize" value="#{jobParameters['entityFetchSize']}" />
+                    <property name="checkpointInterval" value="#{jobParameters['checkpointInterval']}?:200;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
                     <property name="maxResultsPerEntity" value="#{jobParameters['maxResultsPerEntity']}" />
                 </properties>
@@ -87,7 +89,7 @@
             <mapper ref="org.hibernate.search.jsr352.massindexing.impl.steps.lucene.PartitionMapper">
                 <properties>
                     <property name="tenantId" value="#{jobParameters['tenantId']}" />
-                    <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
+                    <property name="idFetchSize" value="#{jobParameters['idFetchSize']}?:1000;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
                     <property name="maxThreads" value="#{jobParameters['maxThreads']}" />
                     <property name="maxResultsPerEntity" value="#{jobParameters['maxResultsPerEntity']}" />

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParametersBuilderTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobParametersBuilderTest.java
@@ -37,7 +37,8 @@ public class MassIndexingJobParametersBuilderTest {
 	private static final boolean OPTIMIZE_AFTER_PURGE = true;
 	private static final boolean OPTIMIZE_ON_FINISH = true;
 	private static final boolean PURGE_ALL_ON_START = true;
-	private static final int FETCH_SIZE = 100000;
+	private static final int ID_FETCH_SIZE = Integer.MIN_VALUE;
+	private static final int ENTITY_FETCH_SIZE = Integer.MIN_VALUE + 1;
 	private static final int MAX_RESULTS_PER_ENTITY = 10_000;
 	private static final int MAX_THREADS = 2;
 	private static final int ROWS_PER_PARTITION = 500;
@@ -47,7 +48,8 @@ public class MassIndexingJobParametersBuilderTest {
 		Properties props = MassIndexingJob.parameters()
 				.forEntities( String.class, Integer.class )
 				.entityManagerFactoryReference( SESSION_FACTORY_NAME )
-				.fetchSize( FETCH_SIZE )
+				.idFetchSize( ID_FETCH_SIZE )
+				.entityFetchSize( ENTITY_FETCH_SIZE )
 				.maxResultsPerEntity( MAX_RESULTS_PER_ENTITY )
 				.maxThreads( MAX_THREADS )
 				.optimizeAfterPurge( OPTIMIZE_AFTER_PURGE )
@@ -58,7 +60,8 @@ public class MassIndexingJobParametersBuilderTest {
 				.build();
 
 		assertEquals( SESSION_FACTORY_NAME, props.getProperty( MassIndexingJobParameters.ENTITY_MANAGER_FACTORY_REFERENCE ) );
-		assertEquals( FETCH_SIZE, Integer.parseInt( props.getProperty( MassIndexingJobParameters.FETCH_SIZE ) ) );
+		assertEquals( ID_FETCH_SIZE, Integer.parseInt( props.getProperty( MassIndexingJobParameters.ID_FETCH_SIZE ) ) );
+		assertEquals( ENTITY_FETCH_SIZE, Integer.parseInt( props.getProperty( MassIndexingJobParameters.ENTITY_FETCH_SIZE ) ) );
 		assertEquals( MAX_RESULTS_PER_ENTITY, Integer.parseInt( props.getProperty( MassIndexingJobParameters.MAX_RESULTS_PER_ENTITY ) ) );
 		assertEquals( OPTIMIZE_AFTER_PURGE, Boolean.parseBoolean( props.getProperty( MassIndexingJobParameters.OPTIMIZE_AFTER_PURGE ) ) );
 		assertEquals( OPTIMIZE_ON_FINISH, Boolean.parseBoolean( props.getProperty( MassIndexingJobParameters.OPTIMIZE_ON_FINISH ) ) );
@@ -163,6 +166,24 @@ public class MassIndexingJobParametersBuilderTest {
 		MassIndexingJob.parameters()
 				.forEntity( UnusedEntity.class )
 				.tenantId( "" );
+	}
+
+	@Test
+	public void testIdFetchSize() throws Exception {
+		for ( int allowedValue : Arrays.asList( Integer.MAX_VALUE, 0, Integer.MIN_VALUE ) ) {
+			MassIndexingJob.parameters()
+					.forEntity( UnusedEntity.class )
+					.idFetchSize( allowedValue );
+		}
+	}
+
+	@Test
+	public void testEntityFetchSize() throws Exception {
+		for ( int allowedValue : Arrays.asList( Integer.MAX_VALUE, 0, Integer.MIN_VALUE ) ) {
+			MassIndexingJob.parameters()
+					.forEntity( UnusedEntity.class )
+					.entityFetchSize( allowedValue );
+		}
 	}
 
 	private static class UnusedEntity {

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReaderTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReaderTest.java
@@ -79,13 +79,15 @@ public class EntityReaderTest {
 
 		final String cacheable = String.valueOf( false );
 		final String entityName = Company.class.getName();
-		final String fetchSize = String.valueOf( 1000 );
+		final String entityFetchSize = String.valueOf( 1000 );
+		final String checkpointInterval = String.valueOf( 1000 );
 		final String hql = null;
 		final String maxResults = String.valueOf( Integer.MAX_VALUE );
 		final String partitionId = String.valueOf( 0 );
 		entityReader = new EntityReader( cacheable,
 				entityName,
-				fetchSize,
+				entityFetchSize,
+				checkpointInterval,
 				hql,
 				maxResults,
 				partitionId,


### PR DESCRIPTION
Hi @yrodiere , here's the PR for ticket <https://hibernate.atlassian.net/browse/HSEARCH-2786>.

I changed my initial mind about the splitting: actually we don't need to create 2 parameters explicitly for entity fetching, only `idFetchSize` would be enough:

- The "ID Fetching" during the phrase of "Partition Mapping" can be achieved by using the parameter `idFetchSize`;
- The "Entity Fetching" during the phrase of "Entity Reading" can be achieve by using the `rowsPerPartitions`. Thus, there's no need to create the 2nd parameter, called `entityFetchSize`.

Additionally, I found that the fetch size can actually be negative. So I disabled the positive-integer validation in `JobContextSetupListener`: we only require that the fetch size to be an integer, but any value is acceptable. You might ask: why this parameter must be validated meanwhile it is optional? Because we provide a default value when user does not fill it: so in any case, it should be filled at the JSR-352 batch runtime point of view.