### PR TITLE
HSEARCH-2803 Change the default value of maxThreads

### DIFF
--- a/documentation/src/main/asciidoc/manual-index.asciidoc
+++ b/documentation/src/main/asciidoc/manual-index.asciidoc
@@ -503,7 +503,7 @@ greater than the value of `checkpointInterval`.
 |`maxThreads`
 |`maxThreads(int)`
 |Optional
-|10
+|The number of partitions
 |The maximum number of threads to use for processing the job. Note the batch runtime cannot
 guarantee the request number of threads are available; it will use as many as it can up to the
 request maximum.

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -198,7 +198,7 @@ public final class MassIndexingJob {
 		/**
 		 * The maximum number of threads to use for processing the job. Note the batch runtime cannot guarantee the
 		 * request number of threads are available; it will use as many as it can up to the request maximum. This
-		 * method is optional, its default value is {@literal 8}.
+		 * method is optional, its default value is the number of partitions.
 		 *
 		 * @param maxThreads the maximum number of threads.
 		 *

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/JobContextSetupListener.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/JobContextSetupListener.java
@@ -149,8 +149,10 @@ public class JobContextSetupListener extends AbstractJobListener {
 	}
 
 	private void validateJobSettings() {
-		int maxThreads = SerializationUtil.parseIntegerParameter( MAX_THREADS, serializedMaxThreads );
-		ValidationUtil.validatePositive( MAX_THREADS, maxThreads );
+		if ( StringHelper.isNotEmpty( serializedMaxThreads ) ) {
+			int maxThreads = SerializationUtil.parseIntegerParameter( MAX_THREADS, serializedMaxThreads );
+			ValidationUtil.validatePositive( MAX_THREADS, maxThreads );
+		}
 
 		// A boolean parameter is validated if its deserialization is successful.
 		SerializationUtil.parseBooleanParameter( OPTIMIZE_ON_FINISH , serializedOptimizedOnFinish );

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
@@ -33,6 +33,7 @@ import org.hibernate.search.jsr352.massindexing.impl.util.MassIndexingPartitionP
 import org.hibernate.search.jsr352.massindexing.impl.util.PartitionBound;
 import org.hibernate.search.jsr352.massindexing.impl.util.PersistenceUtil;
 import org.hibernate.search.jsr352.massindexing.impl.util.SerializationUtil;
+import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import static org.hibernate.search.jsr352.massindexing.MassIndexingJobParameters.FETCH_SIZE;
@@ -151,10 +152,8 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 			}
 
 			// Build partition plan
-			final int threads = SerializationUtil.parseIntegerParameter( MAX_THREADS, serializedMaxThreads );
 			final int partitions = partitionBounds.size();
 			final Properties[] props = new Properties[partitions];
-			log.partitionsPlan( partitions, threads );
 
 			for ( int i = 0; i < partitionBounds.size(); i++ ) {
 				PartitionBound bound = partitionBounds.get( i );
@@ -170,7 +169,12 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 			PartitionPlan partitionPlan = new PartitionPlanImpl();
 			partitionPlan.setPartitionProperties( props );
 			partitionPlan.setPartitions( partitions );
-			partitionPlan.setThreads( threads );
+			if ( StringHelper.isNotEmpty( serializedMaxThreads ) ) {
+				final int threads = SerializationUtil.parseIntegerParameter( MAX_THREADS, serializedMaxThreads );
+				partitionPlan.setThreads( threads );
+			}
+
+			log.partitionsPlan( partitionPlan.getPartitions(), partitionPlan.getThreads() );
 			return partitionPlan;
 		}
 		finally {

--- a/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/jsr352/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -15,7 +15,7 @@
                 <property name="entityManagerFactoryReference" value="#{jobParameters['entityManagerFactoryReference']}" />
                 <property name="entityTypes" value="#{jobParameters['entityTypes']}" />
 
-                <property name="maxThreads" value="#{jobParameters['maxThreads']}?:10;" />
+                <property name="maxThreads" value="#{jobParameters['maxThreads']}" />
                 <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
                 <property name="cacheable" value="#{jobParameters['cacheable']}?:false;" />
                 <property name="optimizeOnFinish" value="#{jobParameters['optimizeOnFinish']}?:true;" />
@@ -87,7 +87,7 @@
                     <property name="tenantId" value="#{jobParameters['tenantId']}" />
                     <property name="fetchSize" value="#{jobParameters['fetchSize']}?:100;" />
                     <property name="customQueryHQL" value="#{jobParameters['customQueryHQL']}" />
-                    <property name="maxThreads" value="#{jobParameters['maxThreads']}?:10;" />
+                    <property name="maxThreads" value="#{jobParameters['maxThreads']}" />
                     <property name="rowsPerPartition" value="#{jobParameters['rowsPerPartition']}?:1000;" />
                 </properties>
             </mapper>


### PR DESCRIPTION
Hi @yrodiere , here's the PR for ticket <https://hibernate.atlassian.net/browse/HSEARCH-2803>

Job parameter `maxThreads` is used to specify the maximum number of threads on which to execute the partitions of 2nd step: the production of Lucene documents. The default was set to 10 be default; now, the default value is the number of partitions, which is more aggressive.

Note the batch runtime cannot guarantee the requested number of threads are available; it will use as many as it can up to the requested maximum.