### PR TITLE
HSEARCH-2824 Update example usage of Mass Indexing Job

### DIFF
--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -32,15 +32,13 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
  * jobOperator.start(
  * 		MassIndexingJob.NAME,
  * 		MassIndexingJob.parameters()
- * 			.forEntities( String.class, Integer.class )
- * 			.fetchSize( 1000 )
- * 			.rowsPerPartition( 10_000 )
- * 			.maxResults( 1000 )
- * 			.maxThreads( 30 )
- * 			.purgeAtStart( true )
+ * 			.forEntities( EntityA.class, EntityB.class )
  * 			.build()
  * );
  * </pre></code>
+ *
+ * You can also add optional parameters to tune your job execution. See our
+ * documentation for more detail.
  *
  * @author Mincong Huang
  */


### PR DESCRIPTION
Hi @yrodiere, here's the PR for <https://hibernate.atlassian.net/browse/HSEARCH-2824>.

I choose simply remove all the optional parameters in the example in Javadoc. Principally because we just want to give a fast overview about how the syntax looks like; and if there's any change in the codebase, we need to update this example, which is quite a pain. If this kind of Javadoc is necessary, I would like to add it in the final PR.